### PR TITLE
chore: Fix last confirmed height

### DIFF
--- a/btcscanner/btc_scanner.go
+++ b/btcscanner/btc_scanner.go
@@ -220,8 +220,8 @@ func (bs *BtcPoller) Bootstrap(startHeight uint64) error {
 }
 
 func (bs *BtcPoller) sendConfirmedBlocksToChan(blocks []*types.IndexedBlock) {
-	bs.confirmedTipBlock = blocks[len(blocks)-1]
 	for i := 0; i < len(blocks); i++ {
+		bs.confirmedTipBlock = blocks[i]
 		bs.confirmedBlocksChan <- blocks[i]
 	}
 }


### PR DESCRIPTION
The confirmed tip block of the BTC poller should be updated one by one and right before it is sent to the channel. Otherwise, when there is more than one block in the input, the state won't match when processing unconfirmed block info