### PR TITLE
chore: Fix cap boundary condition

### DIFF
--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -879,7 +879,7 @@ func (si *StakingIndexer) isOverflow(cap uint64) (bool, error) {
 		return false, fmt.Errorf("failed to get the confirmed TVL: %w", err)
 	}
 
-	return confirmedTvl > cap, nil
+	return confirmedTvl >= cap, nil
 }
 
 func (si *StakingIndexer) GetConfirmedTvl() (uint64, error) {

--- a/indexer/indexer_test.go
+++ b/indexer/indexer_test.go
@@ -83,7 +83,7 @@ func NewTestScenario(r *rand.Rand, t *testing.T, versionedParams *types.ParamsVe
 		// no active staking events created, otherwise, to be an unbonding event
 		if r.Intn(100) < stakingChance || !hasActiveStakingEvent(stakingEvents) {
 			stakingEvent := buildStakingEvent(r, t, height, p)
-			if checkOverflow && tvl > p.StakingCap {
+			if checkOverflow && tvl >= p.StakingCap {
 				stakingEvent.IsOverflow = true
 			} else {
 				tvl += stakingEvent.StakingTxData.StakingAmount


### PR DESCRIPTION
This PR is to fix the cap boundary condition. Now a staking tx is considered to be overflow if the current `tvl >= cap` (previously is `tvl > cap`). For example, the cap is 10 BTCs and we have txs with 1, 9, and 2 BTCs, respectively, we will accept the first 2 transactions and the third one with 2 BTCs will be overflow