### PR TITLE
chore: Fix metrics label

### DIFF
--- a/itest/e2e_test.go
+++ b/itest/e2e_test.go
@@ -476,8 +476,9 @@ func buildWithdrawTx(
 	lockTime uint16,
 	lockedAmount btcutil.Amount,
 ) *wire.MsgTx {
-
+	
 	destAddress, err := btcutil.NewAddressPubKey(stakerPrivKey.PubKey().SerializeCompressed(), regtestParams)
+
 	require.NoError(t, err)
 	destAddressScript, err := txscript.PayToAddrScript(destAddress)
 	require.NoError(t, err)


### PR DESCRIPTION
This PR added more labels to the `invalidTransactionsCounter` metrics to distinguish txs from confirmed and unconfirmed blocks. This PR also changed the log level of invalid transactions from `Error` to `Warning`