### PR TITLE
feat: new command `btc-headers`

### DIFF
--- a/cmd/sid/cli/btc_headers.go
+++ b/cmd/sid/cli/btc_headers.go
@@ -1,0 +1,137 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	babylontypes "github.com/babylonchain/babylon/types"
+	bbnbtclightclienttypes "github.com/babylonchain/babylon/x/btclightclient/types"
+	"github.com/babylonchain/staking-indexer/btcclient"
+	"github.com/babylonchain/staking-indexer/config"
+	"github.com/babylonchain/staking-indexer/log"
+	"github.com/babylonchain/staking-indexer/utils"
+	"github.com/urfave/cli"
+
+	sdkmath "cosmossdk.io/math"
+)
+
+const (
+	outputFileFlag = "outputfile-path"
+)
+
+var BtcHeaderCommand = cli.Command{
+	Name:        "btc-headers",
+	Usage:       "btc-headers 10 15 --outputfile-path ~/myoutput/path/btc-headers.json",
+	Description: `Get BTC headers "from" and "to" a specific block height.`,
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  homeFlag,
+			Usage: "The path to the staking indexer home directory",
+			Value: config.DefaultHomeDir,
+		},
+		cli.StringFlag{
+			Name:  outputFileFlag,
+			Usage: "The path to the output file",
+			Value: filepath.Join(config.DefaultHomeDir, "output-btc-headers.json"),
+		},
+	},
+	Action: btcHeaders,
+}
+
+func btcHeaders(ctx *cli.Context) error {
+	args := ctx.Args()
+	if len(args) != 2 {
+		return fmt.Errorf("not enough params, please specify 'from' and 'to' block")
+	}
+
+	fromStr, toStr := args[0], args[1]
+	fromBlock, err := strconv.ParseUint(fromStr, 10, 64)
+	if err != nil {
+		return fmt.Errorf("unable to parse %s: %w", fromStr, err)
+	}
+
+	toBlock, err := strconv.ParseUint(toStr, 10, 64)
+	if err != nil {
+		return fmt.Errorf("unable to parse %s: %w", toStr, err)
+	}
+
+	if fromBlock > toBlock {
+		return fmt.Errorf("the from %d block should be less than to block %d", fromBlock, toBlock)
+	}
+
+	homePath, err := filepath.Abs(ctx.String(homeFlag))
+	if err != nil {
+		return err
+	}
+	homePath = utils.CleanAndExpandPath(homePath)
+
+	cfg, err := config.LoadConfig(homePath)
+	if err != nil {
+		return fmt.Errorf("failed to load configuration: %w", err)
+	}
+
+	logger, err := log.NewRootLoggerWithFile(config.LogFile(homePath), cfg.LogLevel)
+	if err != nil {
+		return fmt.Errorf("failed to initialize the logger: %w", err)
+	}
+
+	btcClient, err := btcclient.NewBTCClient(
+		cfg.BTCConfig,
+		logger,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to initialize the BTC client: %w", err)
+	}
+
+	btcHeaders, err := BtcHeaderInfo(btcClient, fromBlock, toBlock)
+	if err != nil {
+		return fmt.Errorf("failed to get BTC Header blocks: %w", err)
+	}
+
+	genState := bbnbtclightclienttypes.GenesisState{
+		BtcHeaders: btcHeaders,
+	}
+
+	bz, err := json.MarshalIndent(genState, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to generate json to set to output file %+v: %w", genState, err)
+	}
+
+	outputFilePath := ctx.String(outputFileFlag)
+	file, err := os.OpenFile(outputFilePath, os.O_CREATE, os.ModePerm)
+	if err != nil {
+		return fmt.Errorf("failed to open output file %s: %w", outputFilePath, err)
+	}
+	defer file.Close()
+
+	if _, err := file.Write(bz); err != nil {
+		return fmt.Errorf("failed to write to output file %s: %w", outputFilePath, err)
+	}
+	return nil
+}
+
+// BtcHeaderInfo queries the btc client for (fromBlk ~ toBlk) BTC blocks, converting to BTCHeaderInfo.
+func BtcHeaderInfo(btcClient *btcclient.BTCClient, fromBlk, toBlk uint64) ([]*bbnbtclightclienttypes.BTCHeaderInfo, error) {
+	btcHeaders := make([]*bbnbtclightclienttypes.BTCHeaderInfo, 0, toBlk-fromBlk)
+	var currenWork = sdkmath.ZeroUint()
+
+	for blkHeight := fromBlk; blkHeight < toBlk; blkHeight++ {
+		idxBlock, err := btcClient.GetBlockByHeight(blkHeight)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get block height %d from BTC client: %w", blkHeight, err)
+		}
+		blkHeader := idxBlock.Header
+
+		headerWork := bbnbtclightclienttypes.CalcHeaderWork(blkHeader)
+		currenWork = bbnbtclightclienttypes.CumulativeWork(headerWork, currenWork)
+
+		headerBytes := babylontypes.NewBTCHeaderBytesFromBlockHeader(blkHeader)
+
+		bbnBtcHeaderInfo := bbnbtclightclienttypes.NewBTCHeaderInfo(&headerBytes, headerBytes.Hash(), blkHeight, &currenWork)
+		btcHeaders = append(btcHeaders, bbnBtcHeaderInfo)
+	}
+	return btcHeaders, nil
+}

--- a/cmd/sid/cli/btc_headers_test.go
+++ b/cmd/sid/cli/btc_headers_test.go
@@ -1,0 +1,74 @@
+package cli_test
+
+import (
+	"math/rand"
+	"testing"
+
+	bbnbtclightclienttypes "github.com/babylonchain/babylon/x/btclightclient/types"
+	"github.com/babylonchain/staking-indexer/btcclient"
+	"github.com/babylonchain/staking-indexer/cmd/sid/cli"
+	e2etest "github.com/babylonchain/staking-indexer/itest"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestBtcHeaders(t *testing.T) {
+	r := rand.New(rand.NewSource(10))
+	blocksPerRetarget := 2016
+	genState := bbnbtclightclienttypes.DefaultGenesis()
+
+	initBlocksQnt := r.Intn(15) + blocksPerRetarget
+	btcd, btcClient := StartBtcClientAndBtcHandler(t, initBlocksQnt)
+
+	// from zero height
+	infos, err := cli.BtcHeaderInfo(btcClient, 0, uint64(initBlocksQnt))
+	require.NoError(t, err)
+	require.Equal(t, len(infos), initBlocksQnt)
+
+	// should be valid on genesis, start from zero height.
+	genState.BtcHeaders = infos
+	require.NoError(t, genState.Validate())
+
+	generatedBlocksQnt := r.Intn(15) + 2
+	btcd.GenerateBlocks(generatedBlocksQnt)
+	totalBlks := initBlocksQnt + generatedBlocksQnt
+
+	// check from height with interval
+	fromBlockHeight := blocksPerRetarget - 1
+	toBlockHeight := totalBlks - 2
+
+	infos, err = cli.BtcHeaderInfo(btcClient, uint64(fromBlockHeight), uint64(toBlockHeight))
+	require.NoError(t, err)
+	require.Equal(t, len(infos), int(toBlockHeight-fromBlockHeight))
+
+	// try to check if it is valid on genesis, should fail is not retarget block.
+	genState.BtcHeaders = infos
+	require.EqualError(t, genState.Validate(), "genesis block must be a difficulty adjustment block")
+
+	// from retarget block
+	infos, err = cli.BtcHeaderInfo(btcClient, uint64(blocksPerRetarget), uint64(totalBlks))
+	require.NoError(t, err)
+	require.Equal(t, len(infos), int(totalBlks-blocksPerRetarget))
+
+	// check if it is valid on genesis
+	genState.BtcHeaders = infos
+	require.NoError(t, genState.Validate())
+}
+
+func StartBtcClientAndBtcHandler(t *testing.T, generateNBlocks int) (*e2etest.BitcoindTestHandler, *btcclient.BTCClient) {
+	btcd := e2etest.NewBitcoindHandler(t)
+	btcd.Start()
+	_ = btcd.CreateWallet(e2etest.WalletName, e2etest.Passphrase)
+
+	resp := btcd.GenerateBlocks(generateNBlocks)
+	require.Equal(t, len(resp.Blocks), generateNBlocks)
+
+	cfg := e2etest.DefaultStakingIndexerConfig(t.TempDir())
+	btcClient, err := btcclient.NewBTCClient(
+		cfg.BTCConfig,
+		zap.NewNop(),
+	)
+	require.NoError(t, err)
+
+	return btcd, btcClient
+}

--- a/cmd/sid/cli/init.go
+++ b/cmd/sid/cli/init.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"fmt"
@@ -13,7 +13,7 @@ import (
 
 const forceFlag = "force"
 
-var initCommand = cli.Command{
+var InitCommand = cli.Command{
 	Name:  "init",
 	Usage: "Initialize the staking indexer home directory.",
 	Flags: []cli.Flag{

--- a/cmd/sid/cli/start.go
+++ b/cmd/sid/cli/start.go
@@ -1,4 +1,4 @@
-package main
+package cli
 
 import (
 	"fmt"
@@ -24,7 +24,7 @@ const (
 	paramsPathFlag  = "params-path"
 )
 
-var startCommand = cli.Command{
+var StartCommand = cli.Command{
 	Name:        "start",
 	Usage:       "Start the staking-indexer server",
 	Description: "Start the staking-indexer server.",

--- a/cmd/sid/main.go
+++ b/cmd/sid/main.go
@@ -17,7 +17,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "sid"
 	app.Usage = "Staking Indexer Daemon (sid)."
-	app.Commands = append(app.Commands, sidcli.StartCommand, sidcli.InitCommand)
+	app.Commands = append(app.Commands, sidcli.StartCommand, sidcli.InitCommand, sidcli.BtcHeaderCommand)
 
 	if err := app.Run(os.Args); err != nil {
 		fatal(err)

--- a/cmd/sid/main.go
+++ b/cmd/sid/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	sidcli "github.com/babylonchain/staking-indexer/cmd/sid/cli"
 	"github.com/urfave/cli"
 )
 
@@ -16,7 +17,7 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "sid"
 	app.Usage = "Staking Indexer Daemon (sid)."
-	app.Commands = append(app.Commands, startCommand, initCommand)
+	app.Commands = append(app.Commands, sidcli.StartCommand, sidcli.InitCommand)
 
 	if err := app.Run(os.Args); err != nil {
 		fatal(err)

--- a/itest/test_manager.go
+++ b/itest/test_manager.go
@@ -59,14 +59,14 @@ var (
 	eventuallyWaitTimeOut = 1 * time.Minute
 	eventuallyPollTime    = 500 * time.Millisecond
 	testParamsPath        = "test-params.json"
-	passphrase            = "pass"
-	walletName            = "test-wallet"
+	Passphrase            = "pass"
+	WalletName            = "test-wallet"
 )
 
 func StartManagerWithNBlocks(t *testing.T, n int) *TestManager {
 	h := NewBitcoindHandler(t)
 	h.Start()
-	_ = h.CreateWallet(walletName, passphrase)
+	_ = h.CreateWallet(WalletName, Passphrase)
 	resp := h.GenerateBlocks(n)
 
 	minerAddressDecoded, err := btcutil.DecodeAddress(resp.Address, regtestParams)
@@ -80,13 +80,13 @@ func StartManagerWithNBlocks(t *testing.T, n int) *TestManager {
 }
 
 func StartWithBitcoinHandler(t *testing.T, h *BitcoindTestHandler, minerAddress btcutil.Address, dirPath string, startHeight uint64) *TestManager {
-	cfg := defaultStakingIndexerConfig(dirPath)
+	cfg := DefaultStakingIndexerConfig(dirPath)
 	logger, err := log.NewRootLoggerWithFile(config.LogFile(dirPath), "debug")
 	require.NoError(t, err)
 
 	rpcclient, err := rpcclient.New(cfg.BTCConfig.ToConnConfig(), nil)
 	require.NoError(t, err)
-	err = rpcclient.WalletPassphrase(passphrase, 200)
+	err = rpcclient.WalletPassphrase(Passphrase, 200)
 	require.NoError(t, err)
 	walletPrivKey, err := rpcclient.DumpPrivKey(minerAddress)
 	require.NoError(t, err)
@@ -188,7 +188,7 @@ func ReStartFromHeight(t *testing.T, tm *TestManager, height uint64) *TestManage
 	return restartedTm
 }
 
-func defaultStakingIndexerConfig(homePath string) *config.Config {
+func DefaultStakingIndexerConfig(homePath string) *config.Config {
 	defaultConfig := config.DefaultConfigWithHome(homePath)
 
 	// both wallet and node are bicoind


### PR DESCRIPTION
- Move files into `cli` package to avoid having more than one file in `main` package
- Add new command `btc-headers` to query BTC client for block heights and outputs it into the `x/btclightclient` genesis state format 

> I was thinking we could export just as a slice of `BTCHeaderInfo`, but in the end we might just using it for the genesis

Closes: #32 