### PR TITLE
chore: Refactor processing unconfirmed blocks

### DIFF
--- a/btcscanner/block_handler.go
+++ b/btcscanner/block_handler.go
@@ -13,12 +13,11 @@ import (
 func (bs *BtcPoller) blockEventLoop() {
 	defer bs.wg.Done()
 
+	// register the notifier with the best known tip
 	bestKnownBlock := bs.unconfirmedBlockCache.Tip()
 	bestKnownBlockEpoch := new(notifier.BlockEpoch)
-
 	if bestKnownBlock != nil {
 		bestKnownBlockHash := bestKnownBlock.BlockHash()
-
 		bestKnownBlockEpoch = &notifier.BlockEpoch{
 			Hash:        &bestKnownBlockHash,
 			Height:      bestKnownBlock.Height,
@@ -102,7 +101,6 @@ func (bs *BtcPoller) handleNewBlock(blockEpoch *notifier.BlockEpoch) error {
 	// get the block content by height
 	ib, err := bs.btcClient.GetBlockByHeight(uint64(blockEpoch.Height))
 	if err != nil {
-		// TODO add retry
 		return fmt.Errorf("failed to get block at height %d: %w", blockEpoch.Height, err)
 	}
 	if ib.BlockHash().String() != blockEpoch.Hash.String() {

--- a/btcscanner/block_handler.go
+++ b/btcscanner/block_handler.go
@@ -101,6 +101,10 @@ func (bs *BtcPoller) handleNewBlock(blockEpoch *notifier.BlockEpoch) error {
 
 	// try to extract confirmed blocks
 	confirmedBlocks := bs.unconfirmedBlockCache.TrimConfirmedBlocks(int(params.ConfirmationDepth) - 1)
+
+	// send tip unconfirmed block to the consumer
+	bs.sendTipUnconfirmedBlockToChan()
+
 	if confirmedBlocks == nil {
 		return nil
 	}

--- a/btcscanner/btc_cache_test.go
+++ b/btcscanner/btc_cache_test.go
@@ -1,6 +1,7 @@
 package btcscanner_test
 
 import (
+	"math"
 	"math/rand"
 	"testing"
 
@@ -47,7 +48,8 @@ func FuzzBtcCache(f *testing.F) {
 			invalidNumBlocks = true
 		}
 
-		ibs := datagen.GetRandomIndexedBlocks(r, numBlocks)
+		startHeight := r.Int31n(math.MaxInt32 - int32(numBlocks))
+		ibs := datagen.GetRandomIndexedBlocks(r, uint64(startHeight), numBlocks)
 
 		// Add all indexed blocks to the cache
 		err = cache.Init(ibs)

--- a/btcscanner/btc_scanner.go
+++ b/btcscanner/btc_scanner.go
@@ -17,11 +17,11 @@ type BtcScanner interface {
 
 	// ConfirmedBlocksChan receives every confirmed block will be
 	// sent to this channel
-	ConfirmedBlocksChan() chan *types.IndexedBlock
+	ConfirmedBlocksChan() <-chan *types.IndexedBlock
 
 	// TipUnconfirmedBlocksChan receives the tip unconfirmed block
 	// in the cache after bootstrapping or new block is received
-	TipUnconfirmedBlocksChan() chan *types.IndexedBlock
+	TipUnconfirmedBlocksChan() <-chan *types.IndexedBlock
 
 	LastConfirmedHeight() uint64
 
@@ -139,7 +139,7 @@ func (bs *BtcPoller) Bootstrap(startHeight uint64) error {
 	}
 	defer bs.isSynced.Store(true)
 
-	bs.logger.Info("the bootstrapping starts", zap.Uint64("start height", startHeight))
+	bs.logger.Info("the bootstrapping starts", zap.Uint64("start_height", startHeight))
 
 	// clear all the blocks in the cache to avoid forks
 	bs.unconfirmedBlockCache.RemoveAll()
@@ -243,11 +243,11 @@ func (bs *BtcPoller) GetUnconfirmedBlocks() ([]*types.IndexedBlock, error) {
 	return lastBlocks, nil
 }
 
-func (bs *BtcPoller) ConfirmedBlocksChan() chan *types.IndexedBlock {
+func (bs *BtcPoller) ConfirmedBlocksChan() <-chan *types.IndexedBlock {
 	return bs.confirmedBlocksChan
 }
 
-func (bs *BtcPoller) TipUnconfirmedBlocksChan() chan *types.IndexedBlock {
+func (bs *BtcPoller) TipUnconfirmedBlocksChan() <-chan *types.IndexedBlock {
 	return bs.tipUnconfirmedBlocksChan
 }
 

--- a/btcscanner/btc_scanner.go
+++ b/btcscanner/btc_scanner.go
@@ -111,13 +111,14 @@ func (bs *BtcPoller) Start(startHeight uint64) error {
 }
 
 func (bs *BtcPoller) waitUntilActivation() error {
-	tipHeight, err := bs.btcClient.GetTipHeight()
-	if err != nil {
-		return fmt.Errorf("failed to get the current BTC tip height")
-	}
 	activationHeight := bs.paramsVersions.ParamsVersions[0].ActivationHeight
 
 	for {
+		tipHeight, err := bs.btcClient.GetTipHeight()
+		if err != nil {
+			return fmt.Errorf("failed to get the current BTC tip height")
+		}
+
 		if tipHeight >= activationHeight {
 			break
 		}
@@ -125,7 +126,7 @@ func (bs *BtcPoller) waitUntilActivation() error {
 		bs.logger.Info("waiting to reach the earliest activation height",
 			zap.Uint64("tip_height", tipHeight),
 			zap.Uint64("activation_height", activationHeight))
-		time.Sleep(1 * time.Second)
+		time.Sleep(10 * time.Second)
 	}
 
 	return nil

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -151,6 +151,11 @@ func (si *StakingIndexer) blocksEventLoop() {
 			}
 
 			tipUnconfirmedBlock := update.TipUnconfirmedBlock
+			if tipUnconfirmedBlock == nil {
+				si.logger.Debug("received empty tip unconfirmed block")
+				continue
+			}
+
 			si.logger.Info("received tip unconfirmed block",
 				zap.Int32("height", tipUnconfirmedBlock.Height))
 

--- a/itest/e2e_test.go
+++ b/itest/e2e_test.go
@@ -29,7 +29,7 @@ import (
 
 func TestBTCScanner(t *testing.T) {
 	n := 100
-	tm := StartManagerWithNBlocks(t, n)
+	tm := StartManagerWithNBlocks(t, n, uint64(n))
 	defer tm.Stop()
 
 	count, err := tm.BitcoindHandler.GetBlockCount()
@@ -37,7 +37,6 @@ func TestBTCScanner(t *testing.T) {
 	require.Equal(t, n, count)
 
 	k := int(tm.VersionedParams.ParamsVersions[0].ConfirmationDepth)
-	tm.WaitForNConfirmations(t, k)
 
 	_ = tm.BitcoindHandler.GenerateBlocks(10)
 
@@ -87,8 +86,8 @@ func TestQueueConsumer(t *testing.T) {
 // 5. the withdraw tx is identified by the indexer and consumed by the queue
 func TestStakingLifeCycle(t *testing.T) {
 	// ensure we have UTXOs
-	n := 110
-	tm := StartManagerWithNBlocks(t, n)
+	n := 101
+	tm := StartManagerWithNBlocks(t, n, 100)
 	defer tm.Stop()
 
 	// generate valid staking tx data
@@ -97,7 +96,6 @@ func TestStakingLifeCycle(t *testing.T) {
 	sysParams := tm.VersionedParams.ParamsVersions[0]
 	k := uint64(sysParams.ConfirmationDepth)
 	testStakingData := datagen.GenerateTestStakingData(t, r, sysParams)
-	testStakingData.StakingTime = 120
 	stakingInfo, err := btcstaking.BuildV0IdentifiableStakingOutputs(
 		sysParams.Tag,
 		tm.WalletPrivKey.PubKey(),
@@ -158,20 +156,20 @@ func TestStakingLifeCycle(t *testing.T) {
 
 func TestUnconfirmedTVL(t *testing.T) {
 	// ensure we have UTXOs
-	n := 100
-	tm := StartManagerWithNBlocks(t, n)
+	n := 101
+	tm := StartManagerWithNBlocks(t, n, 100)
 	defer tm.Stop()
+
+	tm.CheckNextUnconfirmedEvent(t, 0, 0)
 
 	// generate valid staking tx data
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	// TODO: test with multiple system parameters
 	sysParams := tm.VersionedParams.ParamsVersions[0]
 	k := sysParams.ConfirmationDepth
-	tm.WaitForNConfirmations(t, int(k))
 
 	// build staking tx
 	testStakingData := datagen.GenerateTestStakingData(t, r, sysParams)
-	testStakingData.StakingTime = 120
 	stakingInfo, err := btcstaking.BuildV0IdentifiableStakingOutputs(
 		sysParams.Tag,
 		tm.WalletPrivKey.PubKey(),
@@ -236,8 +234,8 @@ func TestUnconfirmedTVL(t *testing.T) {
 //     We expect the staking event not to be replayed
 func TestIndexerRestart(t *testing.T) {
 	// ensure we have UTXOs
-	n := 110
-	tm := StartManagerWithNBlocks(t, n)
+	n := 101
+	tm := StartManagerWithNBlocks(t, n, 100)
 	defer tm.Stop()
 
 	// generate valid staking tx data
@@ -246,7 +244,6 @@ func TestIndexerRestart(t *testing.T) {
 	sysParams := tm.VersionedParams.ParamsVersions[0]
 	k := sysParams.ConfirmationDepth
 	testStakingData := datagen.GenerateTestStakingData(t, r, sysParams)
-	testStakingData.StakingTime = 120
 	stakingInfo, err := btcstaking.BuildV0IdentifiableStakingOutputs(
 		sysParams.Tag,
 		tm.WalletPrivKey.PubKey(),
@@ -288,9 +285,6 @@ func TestIndexerRestart(t *testing.T) {
 	restartedTm2 := ReStartFromHeight(t, restartedTm, restartedTm.Si.GetStartHeight())
 	defer restartedTm2.Stop()
 
-	// wait until catch up
-	restartedTm2.WaitForNConfirmations(t, int(k))
-
 	// no staking event should be replayed as
 	// the indexer starts from a higher height
 	restartedTm2.CheckNoStakingEvent(t)
@@ -305,8 +299,8 @@ func TestIndexerRestart(t *testing.T) {
 // 6. the withdraw tx is identified by the indexer
 func TestStakingUnbondingLifeCycle(t *testing.T) {
 	// ensure we have UTXOs
-	n := 110
-	tm := StartManagerWithNBlocks(t, n)
+	n := 101
+	tm := StartManagerWithNBlocks(t, n, 100)
 	defer tm.Stop()
 
 	// generate valid staking tx data
@@ -537,7 +531,7 @@ func getTestStakingData(
 	require.NoError(t, err)
 
 	stakingAmount := btcutil.Amount(100000)
-	stakingTime := uint16(10000)
+	stakingTime := uint16(100)
 
 	return &datagen.TestStakingData{
 		StakerKey:           stakerPrivKey.PubKey(),

--- a/itest/e2e_test.go
+++ b/itest/e2e_test.go
@@ -158,7 +158,7 @@ func TestStakingLifeCycle(t *testing.T) {
 
 func TestUnconfirmedTVL(t *testing.T) {
 	// ensure we have UTXOs
-	n := 110
+	n := 100
 	tm := StartManagerWithNBlocks(t, n)
 	defer tm.Stop()
 
@@ -476,7 +476,7 @@ func buildWithdrawTx(
 	lockTime uint16,
 	lockedAmount btcutil.Amount,
 ) *wire.MsgTx {
-	
+
 	destAddress, err := btcutil.NewAddressPubKey(stakerPrivKey.PubKey().SerializeCompressed(), regtestParams)
 
 	require.NoError(t, err)

--- a/itest/test-params.json
+++ b/itest/test-params.json
@@ -2,7 +2,7 @@
     "versions": [
         {
             "version": 0,
-            "activation_height": 1,
+            "activation_height": 100,
             "staking_cap": 5000000000,
             "tag": "01020304",
             "covenant_pks": [

--- a/itest/test-params.json
+++ b/itest/test-params.json
@@ -9,12 +9,12 @@
                 "03cecdb3f9b99e0d67e806a9d1abd9d8c7811602dc7653bcb657a3faff29b76047"
             ],
             "covenant_quorum": 1,
-            "unbonding_time": 10,
+            "unbonding_time": 20,
             "unbonding_fee": 1000,
             "max_staking_amount": 300000,
             "min_staking_amount": 3000,
-            "max_staking_time": 10000,
-            "min_staking_time": 100,
+            "max_staking_time": 100,
+            "min_staking_time": 50,
             "confirmation_depth": 10
         }
     ]

--- a/itest/test_manager.go
+++ b/itest/test_manager.go
@@ -63,7 +63,7 @@ var (
 	walletName            = "test-wallet"
 )
 
-func StartManagerWithNBlocks(t *testing.T, n int) *TestManager {
+func StartManagerWithNBlocks(t *testing.T, n int, startHeight uint64) *TestManager {
 	h := NewBitcoindHandler(t)
 	h.Start()
 	_ = h.CreateWallet(walletName, passphrase)
@@ -76,7 +76,7 @@ func StartManagerWithNBlocks(t *testing.T, n int) *TestManager {
 	err = os.MkdirAll(dirPath, 0755)
 	require.NoError(t, err)
 
-	return StartWithBitcoinHandler(t, h, minerAddressDecoded, dirPath, 1)
+	return StartWithBitcoinHandler(t, h, minerAddressDecoded, dirPath, startHeight)
 }
 
 func StartWithBitcoinHandler(t *testing.T, h *BitcoindTestHandler, minerAddress btcutil.Address, dirPath string, startHeight uint64) *TestManager {

--- a/testutils/datagen/block.go
+++ b/testutils/datagen/block.go
@@ -1,7 +1,6 @@
 package datagen
 
 import (
-	"math"
 	"math/big"
 	"math/rand"
 
@@ -52,7 +51,7 @@ func GenRandomBlock(r *rand.Rand, prevHash *chainhash.Hash) *wire.MsgBlock {
 }
 
 // GetRandomIndexedBlocks generates a random number of indexed blocks with a random root height
-func GetRandomIndexedBlocks(r *rand.Rand, numBlocks uint64) []*types.IndexedBlock {
+func GetRandomIndexedBlocks(r *rand.Rand, startHeight, numBlocks uint64) []*types.IndexedBlock {
 	var ibs []*types.IndexedBlock
 
 	if numBlocks == 0 {
@@ -60,11 +59,10 @@ func GetRandomIndexedBlocks(r *rand.Rand, numBlocks uint64) []*types.IndexedBloc
 	}
 
 	block := GenRandomBlock(r, nil)
-	prevHeight := r.Int31n(math.MaxInt32 - int32(numBlocks))
-	ib := types.NewIndexedBlockFromMsgBlock(prevHeight, block)
+	ib := types.NewIndexedBlockFromMsgBlock(int32(startHeight), block)
 	prevHash := ib.Header.BlockHash()
 
-	ibs = GetRandomIndexedBlocksFromHeight(r, numBlocks-1, prevHeight, prevHash)
+	ibs = GetRandomIndexedBlocksFromHeight(r, numBlocks-1, int32(startHeight), prevHash)
 	ibs = append([]*types.IndexedBlock{ib}, ibs...)
 	return ibs
 }

--- a/testutils/datagen/params.go
+++ b/testutils/datagen/params.go
@@ -38,7 +38,8 @@ func GenerateGlobalParamsVersions(r *rand.Rand, t *testing.T) *types.ParamsVersi
 	lastStakingCap := btcutil.Amount(0)
 	lastActivationHeight := int32(0)
 	lastCovKeys := make([]*btcec.PublicKey, numCovenants)
-	confirmationDepth := uint16(r.Intn(100) + 1)
+	// confirmation depth is at least 2
+	confirmationDepth := uint16(r.Intn(10) + 2)
 	copy(lastCovKeys, covPks)
 	for version := uint16(0); version <= numVersions; version++ {
 		// These parameters can freely change between versions

--- a/testutils/datagen/params.go
+++ b/testutils/datagen/params.go
@@ -39,7 +39,7 @@ func GenerateGlobalParamsVersions(r *rand.Rand, t *testing.T) *types.ParamsVersi
 	lastActivationHeight := int32(0)
 	lastCovKeys := make([]*btcec.PublicKey, numCovenants)
 	// confirmation depth is at least 2
-	confirmationDepth := uint16(r.Intn(10) + 2)
+	confirmationDepth := uint16(r.Intn(100) + 2)
 	copy(lastCovKeys, covPks)
 	for version := uint16(0); version <= numVersions; version++ {
 		// These parameters can freely change between versions

--- a/testutils/mocks/btc_scanner.go
+++ b/testutils/mocks/btc_scanner.go
@@ -35,10 +35,10 @@ func (m *MockBtcScanner) EXPECT() *MockBtcScannerMockRecorder {
 }
 
 // ConfirmedBlocksChan mocks base method.
-func (m *MockBtcScanner) ConfirmedBlocksChan() chan *types.IndexedBlock {
+func (m *MockBtcScanner) ConfirmedBlocksChan() <-chan *types.IndexedBlock {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConfirmedBlocksChan")
-	ret0, _ := ret[0].(chan *types.IndexedBlock)
+	ret0, _ := ret[0].(<-chan *types.IndexedBlock)
 	return ret0
 }
 
@@ -120,10 +120,10 @@ func (mr *MockBtcScannerMockRecorder) Stop() *gomock.Call {
 }
 
 // TipUnconfirmedBlocksChan mocks base method.
-func (m *MockBtcScanner) TipUnconfirmedBlocksChan() chan *types.IndexedBlock {
+func (m *MockBtcScanner) TipUnconfirmedBlocksChan() <-chan *types.IndexedBlock {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TipUnconfirmedBlocksChan")
-	ret0, _ := ret[0].(chan *types.IndexedBlock)
+	ret0, _ := ret[0].(<-chan *types.IndexedBlock)
 	return ret0
 }
 

--- a/testutils/mocks/btc_scanner.go
+++ b/testutils/mocks/btc_scanner.go
@@ -118,3 +118,17 @@ func (mr *MockBtcScannerMockRecorder) Stop() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockBtcScanner)(nil).Stop))
 }
+
+// TipUnconfirmedBlocksChan mocks base method.
+func (m *MockBtcScanner) TipUnconfirmedBlocksChan() chan *types.IndexedBlock {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TipUnconfirmedBlocksChan")
+	ret0, _ := ret[0].(chan *types.IndexedBlock)
+	return ret0
+}
+
+// TipUnconfirmedBlocksChan indicates an expected call of TipUnconfirmedBlocksChan.
+func (mr *MockBtcScannerMockRecorder) TipUnconfirmedBlocksChan() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TipUnconfirmedBlocksChan", reflect.TypeOf((*MockBtcScanner)(nil).TipUnconfirmedBlocksChan))
+}

--- a/testutils/mocks/btc_scanner.go
+++ b/testutils/mocks/btc_scanner.go
@@ -7,6 +7,7 @@ package mocks
 import (
 	reflect "reflect"
 
+	btcscanner "github.com/babylonchain/staking-indexer/btcscanner"
 	types "github.com/babylonchain/staking-indexer/types"
 	gomock "github.com/golang/mock/gomock"
 )
@@ -34,18 +35,18 @@ func (m *MockBtcScanner) EXPECT() *MockBtcScannerMockRecorder {
 	return m.recorder
 }
 
-// ConfirmedBlocksChan mocks base method.
-func (m *MockBtcScanner) ConfirmedBlocksChan() <-chan *types.IndexedBlock {
+// ChainUpdateInfoChan mocks base method.
+func (m *MockBtcScanner) ChainUpdateInfoChan() <-chan *btcscanner.ChainUpdateInfo {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConfirmedBlocksChan")
-	ret0, _ := ret[0].(<-chan *types.IndexedBlock)
+	ret := m.ctrl.Call(m, "ChainUpdateInfoChan")
+	ret0, _ := ret[0].(<-chan *btcscanner.ChainUpdateInfo)
 	return ret0
 }
 
-// ConfirmedBlocksChan indicates an expected call of ConfirmedBlocksChan.
-func (mr *MockBtcScannerMockRecorder) ConfirmedBlocksChan() *gomock.Call {
+// ChainUpdateInfoChan indicates an expected call of ChainUpdateInfoChan.
+func (mr *MockBtcScannerMockRecorder) ChainUpdateInfoChan() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfirmedBlocksChan", reflect.TypeOf((*MockBtcScanner)(nil).ConfirmedBlocksChan))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChainUpdateInfoChan", reflect.TypeOf((*MockBtcScanner)(nil).ChainUpdateInfoChan))
 }
 
 // GetUnconfirmedBlocks mocks base method.
@@ -117,18 +118,4 @@ func (m *MockBtcScanner) Stop() error {
 func (mr *MockBtcScannerMockRecorder) Stop() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockBtcScanner)(nil).Stop))
-}
-
-// TipUnconfirmedBlocksChan mocks base method.
-func (m *MockBtcScanner) TipUnconfirmedBlocksChan() <-chan *types.IndexedBlock {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TipUnconfirmedBlocksChan")
-	ret0, _ := ret[0].(<-chan *types.IndexedBlock)
-	return ret0
-}
-
-// TipUnconfirmedBlocksChan indicates an expected call of TipUnconfirmedBlocksChan.
-func (mr *MockBtcScannerMockRecorder) TipUnconfirmedBlocksChan() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TipUnconfirmedBlocksChan", reflect.TypeOf((*MockBtcScanner)(nil).TipUnconfirmedBlocksChan))
 }


### PR DESCRIPTION
This PR refactored the way the indexer processes unconfirmed blocks. The indexer used to process unconfirmed blocks after a confirmed block is processed. This PR allowed the indexer to process unconfirmed blocks once a new unconfirmed block is received no matter if there are confirmed blocks.

Some notable changes:
1. introduced a `TipUnconfirmedBlock` channel which sends the tip of the unconfirmed block cache to the consumer once the tip is updated
2. the indexer now processes unconfirmed blocks upon receiving a signal from the `TipUnconfirmedBlock`