### PR TITLE
chore: Identify irregular transactions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21.6
 require (
 	github.com/avast/retry-go/v4 v4.5.1
 	github.com/babylonchain/babylon v0.8.6-0.20240426101001-7778c798e236
-	github.com/babylonchain/staking-queue-client v0.2.0
+	github.com/babylonchain/staking-queue-client v0.2.1
 	github.com/btcsuite/btcd v0.24.0
 	github.com/btcsuite/btcd/btcec/v2 v2.3.2
 	github.com/btcsuite/btcd/btcutil v1.1.5

--- a/go.sum
+++ b/go.sum
@@ -283,8 +283,8 @@ github.com/aws/aws-sdk-go v1.44.312/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
 github.com/babylonchain/babylon v0.8.6-0.20240426101001-7778c798e236 h1:Ydna4VcP56xu1+zdgygqHdSCeMduZjuznVhr4exO5do=
 github.com/babylonchain/babylon v0.8.6-0.20240426101001-7778c798e236/go.mod h1:lfeASLNJgcUsX7LEns3HRUv0k+MjzcB2q2AMasfz38M=
-github.com/babylonchain/staking-queue-client v0.2.0 h1:kktKgXJXDAheBv82s7LV5L2CPAfzhtHllNrIopXGjIo=
-github.com/babylonchain/staking-queue-client v0.2.0/go.mod h1:mEgA6N3SnwFwGEOsUYr/HdjpKa13Wck08MS7VY/Icvo=
+github.com/babylonchain/staking-queue-client v0.2.1 h1:FKbxUUOoCydAsUoj9XQMIQT1S79ThX9p7vVc5yjWm8c=
+github.com/babylonchain/staking-queue-client v0.2.1/go.mod h1:mEgA6N3SnwFwGEOsUYr/HdjpKa13Wck08MS7VY/Icvo=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=

--- a/indexer/errors.go
+++ b/indexer/errors.go
@@ -3,9 +3,6 @@ package indexer
 import "errors"
 
 var (
-	// ErrInvalidGlobalParameters the global parameters are invalid
-	ErrInvalidGlobalParameters = errors.New("invalid parameters")
-
 	// ErrInvalidUnbondingTx the transaction spends the unbonding path but is invalid
 	ErrInvalidUnbondingTx = errors.New("invalid unbonding tx")
 

--- a/indexer/indexer_test.go
+++ b/indexer/indexer_test.go
@@ -425,6 +425,15 @@ func FuzzVerifyUnbondingTx(f *testing.F) {
 		isValid, err = stakingIndexer.IsValidUnbondingTx(unbondingTx.MsgTx(), storedStakingTx, params)
 		require.ErrorIs(t, err, indexer.ErrInvalidUnbondingTx)
 		require.False(t, isValid)
+
+		// 5. test IsValidUnbondingTx with invalid unbonding tx (random unbonding time in params), expect (false, ErrInvalidUnbondingTx)
+		newParams2 := *params
+		newParams2.UnbondingTime = uint16(bbndatagen.RandomIntOtherThan(r, int(params.UnbondingTime), 1000))
+		unbondingTx = datagen.GenerateUnbondingTxFromStaking(t, &newParams2, stakingData, stakingTx.Hash(), 0)
+		// pass the old params
+		isValid, err = stakingIndexer.IsValidUnbondingTx(unbondingTx.MsgTx(), storedStakingTx, params)
+		require.ErrorIs(t, err, indexer.ErrInvalidUnbondingTx)
+		require.False(t, isValid)
 	})
 }
 


### PR DESCRIPTION
This PR added identifying irregular unbonding/withdrawal transactions via witness script and alerting if irregular unbonding/withdraw transactions are found.

An unbonding transaction is invalid if (1) its witness unlocks the unbonding path, (2) the transaction output is not expected (e.g. can be unlocked within different unbonding time with the parameters). This case can happen when the staker colludes with the covenant committed and the latter signs an invalid unbonding request.

A withdrawal transaction is invalid if it spends the staking output of a staking/unbonding tx but it does not unlock the expected time-lock path. This case can happen if an unexpected unlocking path is constructed and it indicates a critical issue in our system. Two new alerts for invalid transactions should be added, i.e.  `"confirmed_withdraw_staking_transactions"` and `"confirmed_withdraw_unbonding_transactions"`. cc @liam-icheng-lai 