### PR TITLE
chore: improve btc headers

### DIFF
--- a/btcscanner/expected_btc_client.go
+++ b/btcscanner/expected_btc_client.go
@@ -2,9 +2,11 @@ package btcscanner
 
 import (
 	"github.com/babylonchain/staking-indexer/types"
+	"github.com/btcsuite/btcd/wire"
 )
 
 type Client interface {
 	GetTipHeight() (uint64, error)
 	GetBlockByHeight(height uint64) (*types.IndexedBlock, error)
+	GetBlockHeaderByHeight(height uint64) (*wire.BlockHeader, error)
 }

--- a/cmd/sid/cli/btc_headers.go
+++ b/cmd/sid/cli/btc_headers.go
@@ -124,11 +124,10 @@ func BtcHeaderInfoList(btcClient btcscanner.Client, fromBlk, toBlk uint64) ([]*b
 	var currenWork = sdkmath.ZeroUint()
 
 	for blkHeight := fromBlk; blkHeight <= toBlk; blkHeight++ {
-		idxBlock, err := btcClient.GetBlockByHeight(blkHeight)
+		blkHeader, err := btcClient.GetBlockHeaderByHeight(blkHeight)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get block height %d from BTC client: %w", blkHeight, err)
 		}
-		blkHeader := idxBlock.Header
 
 		headerWork := bbnbtclightclienttypes.CalcHeaderWork(blkHeader)
 		currenWork = bbnbtclightclienttypes.CumulativeWork(headerWork, currenWork)

--- a/cmd/sid/cli/btc_headers_test.go
+++ b/cmd/sid/cli/btc_headers_test.go
@@ -32,8 +32,8 @@ func FuzzBtcHeaders(f *testing.F) {
 
 		for i := 0; i < int(numBlocks); i++ {
 			idxBlock := chainIndexedBlocks[i]
-			mockBtcClient.EXPECT().GetBlockByHeight(gomock.Eq(uint64(idxBlock.Height))).
-				Return(idxBlock, nil).AnyTimes()
+			mockBtcClient.EXPECT().GetBlockHeaderByHeight(gomock.Eq(uint64(idxBlock.Height))).
+				Return(idxBlock.Header, nil).AnyTimes()
 		}
 
 		infos, err := cli.BtcHeaderInfoList(mockBtcClient, startHeight, endHeight)

--- a/testutils/mocks/btc_client.go
+++ b/testutils/mocks/btc_client.go
@@ -9,6 +9,7 @@ import (
 
 	types "github.com/babylonchain/staking-indexer/types"
 	gomock "github.com/golang/mock/gomock"
+	"github.com/btcsuite/btcd/wire"
 )
 
 // MockClient is a mock of Client interface.
@@ -47,6 +48,21 @@ func (m *MockClient) GetBlockByHeight(height uint64) (*types.IndexedBlock, error
 func (mr *MockClientMockRecorder) GetBlockByHeight(height interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlockByHeight", reflect.TypeOf((*MockClient)(nil).GetBlockByHeight), height)
+}
+
+// GetBlockHeaderByHeight mocks base method.
+func (m *MockClient) GetBlockHeaderByHeight(height uint64) (*wire.BlockHeader, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBlockHeaderByHeight", height)
+	ret0, _ := ret[0].(*wire.BlockHeader)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBlockHeaderByHeight indicates an expected call of GetBlockHeaderByHeight.
+func (mr *MockClientMockRecorder) GetBlockHeaderByHeight(height interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlockHeaderByHeight", reflect.TypeOf((*MockClient)(nil).GetBlockHeaderByHeight), height)
 }
 
 // GetTipHeight mocks base method.


### PR DESCRIPTION
- Add new func `GetBlockHeaderByHeight(height uint64) (*wire.BlockHeader, error)` to `BTCClient`
- Improve performance of `BtcHeaderInfoList` to only load the header instead of the whole block