### PR TITLE
chore: Fix bootstrapping height

### DIFF
--- a/btcscanner/block_handler.go
+++ b/btcscanner/block_handler.go
@@ -9,10 +9,10 @@ import (
 	"github.com/babylonchain/staking-indexer/types"
 )
 
-// blockEventLoop handles new blocks from the BTC client unpon new block event
+// blockEventLoop handles new blocks from the BTC client upon new block event
 // Note: in case of rollback, the blockNotifier will emit information about new
 // best block for every new block after rollback
-func (bs *BtcPoller) blockEventLoop() {
+func (bs *BtcPoller) blockEventLoop(startHeight uint64) {
 	defer bs.wg.Done()
 
 	var (
@@ -58,9 +58,16 @@ func (bs *BtcPoller) blockEventLoop() {
 					zap.Error(err))
 
 				if bs.isSynced.Swap(false) {
-					err := bs.Bootstrap(bs.LastConfirmedHeight() + 1)
+					bootStrapHeight := startHeight
+					lastConfirmedHeight := bs.LastConfirmedHeight()
+					if lastConfirmedHeight != 0 {
+						bootStrapHeight = lastConfirmedHeight + 1
+					}
+
+					err := bs.Bootstrap(bootStrapHeight)
 					if err != nil {
 						bs.logger.Error("failed to bootstrap",
+							zap.Uint64("start_height", bootStrapHeight),
 							zap.Error(err))
 					}
 				}

--- a/btcscanner/btc_scanner.go
+++ b/btcscanner/btc_scanner.go
@@ -103,7 +103,7 @@ func (bs *BtcPoller) Start(startHeight uint64) error {
 
 	// start handling new blocks
 	bs.wg.Add(1)
-	go bs.blockEventLoop()
+	go bs.blockEventLoop(startHeight)
 
 	bs.logger.Info("the BTC scanner is started")
 


### PR DESCRIPTION
This PR fixed an issue about bootstrapping. When reorg happens, the poller needs to bootstrap. If the poller does not have any confirmed block at the moment, the last confirmed block height will return `0`. In this case, the bootstrapping height should be the original `start height`