### PR TITLE
hotfix: Fix bootstrapping isSync reset

### DIFF
--- a/btcscanner/btc_scanner.go
+++ b/btcscanner/btc_scanner.go
@@ -183,6 +183,9 @@ func (bs *BtcPoller) Bootstrap(startHeight uint64) error {
 		confirmedBlocks = append(confirmedBlocks, tempConfirmedBlocks...)
 	}
 
+	// ensure that `isSynced` is set to true
+	bs.isSynced.Store(true)
+
 	bs.commitChainUpdate(confirmedBlocks)
 
 	bs.logger.Info("bootstrapping is finished",

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -1062,15 +1062,15 @@ func getTxHex(tx *wire.MsgTx) (string, error) {
 // validateStakingTx performs the validation checks for the staking tx
 // such as min and max staking amount and staking time
 func (si *StakingIndexer) validateStakingTx(params *types.GlobalParams, stakingData *btcstaking.ParsedV0StakingTx) error {
-	value := stakingData.StakingOutput.Value
+	value := btcutil.Amount(stakingData.StakingOutput.Value)
 	// Minimum staking amount check
-	if value < int64(params.MinStakingAmount) {
+	if value < params.MinStakingAmount {
 		return fmt.Errorf("%w: staking amount is too low, expected: %v, got: %v",
 			ErrInvalidStakingTx, params.MinStakingAmount, value)
 	}
 
 	// Maximum staking amount check
-	if value > int64(params.MaxStakingAmount) {
+	if value > params.MaxStakingAmount {
 		return fmt.Errorf("%w: staking amount is too high, expected: %v, got: %v",
 			ErrInvalidStakingTx, params.MaxStakingAmount, value)
 	}
@@ -1086,6 +1086,7 @@ func (si *StakingIndexer) validateStakingTx(params *types.GlobalParams, stakingD
 		return fmt.Errorf("%w: staking time is too low, expected: %v, got: %v",
 			ErrInvalidStakingTx, params.MinStakingTime, stakingData.OpReturnData.StakingTime)
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
This PR fixed a bug which might cause skipping processing unconfirmed blocks.

During bootstrapping, `isSynced` should be set to `true` before calling `commitChainUpdate` even though we have `defer isSynced.Store(true)`. Otherwise, there's a small chance that `defer isSynced.Store(true)` is called after `chainUpdated` is processed, and the unconfirmed block will not be processed (requiring `isSynced` to be `true`)