### PR TITLE
hotfix: More validation on parameters

### DIFF
--- a/params/params.go
+++ b/params/params.go
@@ -39,8 +39,8 @@ func parseConfirmationDepthValue(confirmationDepth uint64) (uint16, error) {
 		return 0, fmt.Errorf("timelock value %d is too large. Max: %d", confirmationDepth, math.MaxUint16)
 	}
 
-	if err := checkPositive(confirmationDepth); err != nil {
-		return 0, fmt.Errorf("invalid confirmation depth value: %w", err)
+	if confirmationDepth <= 1 {
+		return 0, fmt.Errorf("confirmation depth value should be at least 2, got %d", confirmationDepth)
 	}
 
 	return uint16(confirmationDepth), nil
@@ -179,7 +179,7 @@ func ParseGlobalParams(p *GlobalParams) (*ParsedGlobalParams, error) {
 			if cv.StakingCap < pv.StakingCap {
 				return nil, fmt.Errorf("invalid params with version %d. staking cap cannot be decreased in later versions", cv.Version)
 			}
-			if cv.ActivationHeight < pv.ActivationHeight {
+			if cv.ActivationHeight <= pv.ActivationHeight {
 				return nil, fmt.Errorf("invalid params with version %d. activation height cannot be overlapping between earlier and later versions", cv.Version)
 			}
 		}

--- a/params/params_test.go
+++ b/params/params_test.go
@@ -43,7 +43,7 @@ func generateInitParams(t *testing.T, r *rand.Rand) *params.VersionedGlobalParam
 		MinStakingAmount:  uint64(r.Int63n(1000000) + 1000000),
 		MaxStakingTime:    math.MaxUint16,
 		MinStakingTime:    uint64(r.Int63n(10000) + 10000),
-		ConfirmationDepth: uint64(r.Int63n(10) + 1),
+		ConfirmationDepth: uint64(r.Int63n(10) + 2),
 	}
 
 	return &gp


### PR DESCRIPTION
This PR fixed two isseus around parameter validation:
* the activation height cannot be equal across versions
* the confirmation depth should be at least 2