### PR TITLE
feat: Add time-based cap

### DIFF
--- a/doc/staking.md
+++ b/doc/staking.md
@@ -35,6 +35,7 @@ Bitcoin activation height. Each version contains the following:
   "version": <params_version>,
   "activation_height": <bitcoin_activation_height>,
   "staking_cap": <satoshis_staking_cap_of_version>,
+  "cap_height": <bitcoin_cap_height>,
   "tag": "<magic_bytes_to_identify_staking_txs>",
   "covenant_pks": [
     "<covenant_btc_pk1>",

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -1091,21 +1091,18 @@ func (si *StakingIndexer) validateStakingTx(params *types.GlobalParams, stakingD
 }
 
 func (si *StakingIndexer) isOverflow(height uint64, params *types.GlobalParams) (bool, error) {
-	isTimeBased, err := params.IsTimeBasedCap()
-	if err != nil {
-		return false, err
+	isTimeBased := params.IsTimeBasedCap()
+
+	if isTimeBased && height < params.ActivationHeight {
+		panic(fmt.Errorf("the transaction height %d should not be lower than the param activation height: %d",
+			height, params.ActivationHeight))
 	}
 
-	if isTimeBased {
-		if height < params.ActivationHeight {
-			return false, fmt.Errorf("the transaction height %d should not be lower than the param activation height: %d",
-				height, params.ActivationHeight)
-		}
+	if isTimeBased && height > params.CapHeight {
+		return true, nil
+	}
 
-		if height > params.CapHeight {
-			return true, nil
-		}
-
+	if isTimeBased && height <= params.CapHeight {
 		return false, nil
 	}
 

--- a/indexer/indexer_test.go
+++ b/indexer/indexer_test.go
@@ -593,10 +593,7 @@ func NewMockedBtcScanner(t *testing.T, chainUpdateInfoChan chan *btcscanner.Chai
 }
 
 func isOverflow(t *testing.T, height uint64, tvl btcutil.Amount, params *types.GlobalParams) bool {
-	isTimeBased, err := params.IsTimeBasedCap()
-	require.NoError(t, err)
-
-	if isTimeBased {
+	if params.IsTimeBasedCap() {
 		require.GreaterOrEqual(t, height, params.ActivationHeight)
 
 		return height > params.CapHeight

--- a/indexer/indexer_test.go
+++ b/indexer/indexer_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/babylonchain/staking-indexer/btcscanner"
 	"github.com/babylonchain/staking-indexer/config"
 	"github.com/babylonchain/staking-indexer/indexer"
-	"github.com/babylonchain/staking-indexer/indexerstore"
 	"github.com/babylonchain/staking-indexer/testutils"
 	"github.com/babylonchain/staking-indexer/testutils/datagen"
 	"github.com/babylonchain/staking-indexer/testutils/mocks"
@@ -555,122 +554,6 @@ func FuzzValidateWithdrawTxFromUnbonding(f *testing.F) {
 	})
 }
 
-func FuzzTestOverflow(f *testing.F) {
-	bbndatagen.AddRandomSeedsToFuzzer(f, 10)
-
-	f.Fuzz(func(t *testing.T, seed int64) {
-		r := rand.New(rand.NewSource(seed))
-
-		homePath := filepath.Join(t.TempDir(), "indexer")
-		cfg := config.DefaultConfigWithHome(homePath)
-
-		sysParamsVersions := datagen.GenerateGlobalParamsVersions(r, t)
-
-		db, err := cfg.DatabaseConfig.GetDbBackend()
-		require.NoError(t, err)
-		chainUpdateInfoChan := make(chan *btcscanner.ChainUpdateInfo)
-		mockBtcScanner := NewMockedBtcScanner(t, chainUpdateInfoChan)
-		stakingIndexer, err := indexer.NewStakingIndexer(cfg, zap.NewNop(), NewMockedConsumer(t), db, sysParamsVersions, mockBtcScanner)
-		require.NoError(t, err)
-		defer func() {
-			err = db.Close()
-			require.NoError(t, err)
-		}()
-
-		// Select the first params versions to play with
-		params := sysParamsVersions.ParamsVersions[0]
-		// Accumulate the test data
-		var stakingTxData []*StakingTxData
-		// Keep sending staking tx until the staking cap is reached for the very last tx
-		for {
-			stakingData, tvl, storedStakingTx, stakingTx := sendStakingTx(
-				t, r, stakingIndexer, params, stakingTxData,
-				uint64(params.ActivationHeight)+1,
-			)
-			stakingTxData = append(stakingTxData, &StakingTxData{
-				StakingTx:   stakingTx,
-				StakingData: stakingData,
-			})
-			// ~10% chance to trigger unbonding tx on existing staking tx to reduce the tvl
-			if r.Intn(10) == 0 {
-				sendUnbondingTx(t, stakingIndexer, params, stakingTxData, r)
-			}
-
-			// Let's break if the staking tx is overflow
-			if storedStakingTx.IsOverflow {
-				require.True(t, tvl > uint64(params.StakingCap))
-				break
-			}
-			require.True(t, tvl <= uint64(params.StakingCap))
-		}
-
-		// Unbond some of the tx so that new staking tx can be processed
-		for {
-			sendUnbondingTx(t, stakingIndexer, params, stakingTxData, r)
-			// Let's break if the tvl is below max staking value
-			tvl, err := stakingIndexer.GetConfirmedTvl()
-			require.NoError(t, err)
-			if tvl < uint64(params.StakingCap) {
-				break
-			}
-		}
-
-		// Send staking tx again so that it will be accepted until overflow again
-		for {
-			stakingData, tvl, storedStakingTx, stakingTx := sendStakingTx(
-				t, r, stakingIndexer, params, stakingTxData,
-				uint64(params.ActivationHeight)+1,
-			)
-			stakingTxData = append(stakingTxData, &StakingTxData{
-				StakingTx:   stakingTx,
-				StakingData: stakingData,
-			})
-			if storedStakingTx.IsOverflow {
-				require.True(t, tvl > uint64(params.StakingCap))
-				break
-			}
-			require.True(t, tvl <= uint64(params.StakingCap))
-		}
-
-		// Now, let's test the overflow with the second params
-		secondParam := sysParamsVersions.ParamsVersions[1]
-
-		// Let's send more staking txs until the staking cap is exceeded again
-		for {
-			stakingData := datagen.GenerateTestStakingData(t, r, secondParam)
-			_, stakingTx := datagen.GenerateStakingTxFromTestData(t, r, secondParam, stakingData)
-			// For a valid tx, its btc height is always larger than the activation height
-			mockedHeight := uint64(secondParam.ActivationHeight) + 1
-			tvl, err := stakingIndexer.GetConfirmedTvl()
-			require.NoError(t, err)
-			err = stakingIndexer.ProcessStakingTx(
-				stakingTx.MsgTx(),
-				getParsedStakingData(stakingData, stakingTx.MsgTx(), secondParam),
-				mockedHeight, time.Now(), secondParam)
-			require.NoError(t, err)
-			storedStakingTx, err := stakingIndexer.GetStakingTxByHash(stakingTx.Hash())
-			require.NoError(t, err)
-			require.NotNil(t, storedStakingTx)
-
-			stakingTxData = append(stakingTxData, &StakingTxData{
-				StakingTx:   stakingTx,
-				StakingData: stakingData,
-			})
-			// ~20% chance to trigger unbonding tx on existing staking tx to reduce the tvl
-			if r.Intn(5) == 0 {
-				sendUnbondingTx(t, stakingIndexer, secondParam, stakingTxData, r)
-			}
-
-			// Let's break if the staking tx is overflow
-			if storedStakingTx.IsOverflow {
-				require.True(t, tvl > uint64(secondParam.StakingCap))
-				break
-			}
-			require.True(t, tvl <= uint64(secondParam.StakingCap))
-		}
-	})
-}
-
 func getParsedStakingData(data *datagen.TestStakingData, tx *wire.MsgTx, params *types.GlobalParams) *btcstaking.ParsedV0StakingTx {
 	return &btcstaking.ParsedV0StakingTx{
 		StakingOutput:     tx.TxOut[0],
@@ -707,47 +590,6 @@ func NewMockedBtcScanner(t *testing.T, chainUpdateInfoChan chan *btcscanner.Chai
 	mockBtcScanner.EXPECT().Stop().Return(nil).AnyTimes()
 
 	return mockBtcScanner
-}
-
-// This helper method will randomly select a staking tx from stakingTxData and unbond it
-func sendUnbondingTx(
-	t *testing.T, stakingIndexer *indexer.StakingIndexer,
-	params *types.GlobalParams, stakingTxData []*StakingTxData, r *rand.Rand,
-) {
-	// select a random staking tx from stakingTxData and unbond it if it is not already unbonded
-	data := stakingTxData[r.Intn(len(stakingTxData))]
-	if data.Unbonded {
-		return
-	}
-	// unbond the staking tx
-	unbondingTx := datagen.GenerateUnbondingTxFromStaking(t, params, data.StakingData, data.StakingTx.Hash(), 0)
-	mockedHeight := uint64(params.ActivationHeight) + 1
-	err := stakingIndexer.ProcessUnbondingTx(
-		unbondingTx.MsgTx(),
-		data.StakingTx.Hash(),
-		mockedHeight, time.Now(), params)
-	require.NoError(t, err)
-	data.Unbonded = true
-}
-
-func sendStakingTx(
-	t *testing.T, r *rand.Rand, stakingIndexer *indexer.StakingIndexer,
-	params *types.GlobalParams, stakingTxData []*StakingTxData, height uint64,
-) (*datagen.TestStakingData, uint64, *indexerstore.StoredStakingTransaction, *btcutil.Tx) {
-	stakingData := datagen.GenerateTestStakingData(t, r, params)
-	_, stakingTx := datagen.GenerateStakingTxFromTestData(t, r, params, stakingData)
-	tvl, err := stakingIndexer.GetConfirmedTvl()
-	require.NoError(t, err)
-	err = stakingIndexer.ProcessStakingTx(
-		stakingTx.MsgTx(),
-		getParsedStakingData(stakingData, stakingTx.MsgTx(), params),
-		height, time.Now(), params)
-	require.NoError(t, err)
-	storedStakingTx, err := stakingIndexer.GetStakingTxByHash(stakingTx.Hash())
-	require.NoError(t, err)
-	require.NotNil(t, storedStakingTx)
-
-	return stakingData, tvl, storedStakingTx, stakingTx
 }
 
 func isOverflow(t *testing.T, height uint64, tvl btcutil.Amount, params *types.GlobalParams) bool {

--- a/indexer/indexer_test.go
+++ b/indexer/indexer_test.go
@@ -757,11 +757,7 @@ func isOverflow(t *testing.T, height uint64, tvl btcutil.Amount, params *types.G
 	if isTimeBased {
 		require.GreaterOrEqual(t, height, params.ActivationHeight)
 
-		if height > params.CapHeight {
-			return true
-		}
-
-		return false
+		return height > params.CapHeight
 	}
 
 	return tvl >= params.StakingCap

--- a/itest/test-params.json
+++ b/itest/test-params.json
@@ -16,6 +16,23 @@
             "max_staking_time": 100,
             "min_staking_time": 50,
             "confirmation_depth": 10
+        },
+        {
+            "version": 1,
+            "activation_height": 110,
+            "cap_height": 120,
+            "tag": "01020304",
+            "covenant_pks": [
+                "03cecdb3f9b99e0d67e806a9d1abd9d8c7811602dc7653bcb657a3faff29b76047"
+            ],
+            "covenant_quorum": 1,
+            "unbonding_time": 20,
+            "unbonding_fee": 1000,
+            "max_staking_amount": 300000,
+            "min_staking_amount": 3000,
+            "max_staking_time": 100,
+            "min_staking_time": 50,
+            "confirmation_depth": 10
         }
     ]
 }

--- a/itest/test_manager.go
+++ b/itest/test_manager.go
@@ -235,7 +235,6 @@ func (tm *TestManager) BuildStakingTx(
 	r *rand.Rand,
 	params *types.GlobalParams,
 ) (*wire.MsgTx, *datagen.TestStakingData, *btcstaking.IdentifiableStakingInfo) {
-
 	testStakingData := datagen.GenerateTestStakingData(t, r, params)
 	stakingInfo, err := btcstaking.BuildV0IdentifiableStakingOutputs(
 		params.Tag,

--- a/params/params.go
+++ b/params/params.go
@@ -45,25 +45,19 @@ func parseConfirmationDepthValue(confirmationDepth uint64) (uint16, error) {
 	return uint16(confirmationDepth), nil
 }
 
-// either staking cap and cap height should be positive
-// if cap height is positive, then it should be greater
-// than the activation height
-func parseCap(stakingCap, capHeight, activationHeight uint64) (btcutil.Amount, uint64, error) {
-	if stakingCap != 0 {
-		if capHeight != 0 {
-			return 0, 0, fmt.Errorf("only either of staking cap and cap height can be set")
-		}
-
-		parsedStakingCap, err := parseBtcValue(stakingCap)
-		return parsedStakingCap, 0, err
+// either staking cap and cap height should be positive if cap height is positive
+func parseCap(stakingCap, capHeight uint64) (btcutil.Amount, uint64, error) {
+	if stakingCap != 0 && capHeight != 0 {
+		return 0, 0, fmt.Errorf("only either of staking cap and cap height can be set")
 	}
 
-	if capHeight == 0 {
+	if stakingCap == 0 && capHeight == 0 {
 		return 0, 0, fmt.Errorf("either of staking cap and cap height must be set")
 	}
 
-	if capHeight <= activationHeight {
-		return 0, 0, fmt.Errorf("the cap height %d should be greater than the activation height %d", capHeight, activationHeight)
+	if stakingCap != 0 {
+		parsedStakingCap, err := parseBtcValue(stakingCap)
+		return parsedStakingCap, 0, err
 	}
 
 	return 0, capHeight, nil
@@ -324,7 +318,7 @@ func parseVersionedGlobalParams(p *VersionedGlobalParams) (*ParsedVersionedGloba
 		return nil, fmt.Errorf("invalid confirmation_depth: %w", err)
 	}
 
-	stakingCap, capHeight, err := parseCap(p.StakingCap, p.CapHeight, p.ActivationHeight)
+	stakingCap, capHeight, err := parseCap(p.StakingCap, p.CapHeight)
 	if err != nil {
 		return nil, fmt.Errorf("invalid cap: %w", err)
 	}

--- a/params/params.go
+++ b/params/params.go
@@ -347,19 +347,6 @@ func parseVersionedGlobalParams(p *VersionedGlobalParams) (*ParsedVersionedGloba
 	}, nil
 }
 
-func (g *ParsedGlobalParams) getVersionedGlobalParamsByHeight(btcHeight uint64) *ParsedVersionedGlobalParams {
-	// Iterate the list in reverse (i.e. decreasing ActivationHeight)
-	// and identify the first element that has an activation height below
-	// the specified BTC height.
-	for i := len(g.Versions) - 1; i >= 0; i-- {
-		paramsVersion := g.Versions[i]
-		if paramsVersion.ActivationHeight <= btcHeight {
-			return paramsVersion
-		}
-	}
-	return nil
-}
-
 func (g *ParsedGlobalParams) ToGlobalParams() *types.ParamsVersions {
 	versionedParams := make([]*types.GlobalParams, len(g.Versions))
 	for i, p := range g.Versions {

--- a/params/params.go
+++ b/params/params.go
@@ -1,7 +1,6 @@
 package params
 
 import (
-	"context"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -44,6 +43,30 @@ func parseConfirmationDepthValue(confirmationDepth uint64) (uint16, error) {
 	}
 
 	return uint16(confirmationDepth), nil
+}
+
+// either staking cap and cap height should be positive
+// if cap height is positive, then it should be greater
+// than the activation height
+func parseCap(stakingCap, capHeight, activationHeight uint64) (btcutil.Amount, uint64, error) {
+	if stakingCap != 0 {
+		if capHeight != 0 {
+			return 0, 0, fmt.Errorf("only either of staking cap and cap height can be set")
+		}
+
+		parsedStakingCap, err := parseBtcValue(stakingCap)
+		return parsedStakingCap, 0, err
+	}
+
+	if capHeight == 0 {
+		return 0, 0, fmt.Errorf("either of staking cap and cap height must be set")
+	}
+
+	if capHeight <= activationHeight {
+		return 0, 0, fmt.Errorf("the cap height %d should be greater than the activation height %d", capHeight, activationHeight)
+	}
+
+	return 0, capHeight, nil
 }
 
 func parseBtcValue(value uint64) (btcutil.Amount, error) {
@@ -102,6 +125,7 @@ type VersionedGlobalParams struct {
 	Version           uint64   `json:"version"`
 	ActivationHeight  uint64   `json:"activation_height"`
 	StakingCap        uint64   `json:"staking_cap"`
+	CapHeight         uint64   `json:"cap_height"`
 	Tag               string   `json:"tag"`
 	CovenantPks       []string `json:"covenant_pks"`
 	CovenantQuorum    uint64   `json:"covenant_quorum"`
@@ -122,6 +146,7 @@ type ParsedVersionedGlobalParams struct {
 	Version           uint64
 	ActivationHeight  uint64
 	StakingCap        btcutil.Amount
+	CapHeight         uint64
 	Tag               []byte
 	CovenantPks       []*btcec.PublicKey
 	CovenantQuorum    uint32
@@ -161,7 +186,7 @@ func ParseGlobalParams(p *GlobalParams) (*ParsedGlobalParams, error) {
 	}
 	var parsedVersions []*ParsedVersionedGlobalParams
 
-	for _, v := range p.Versions {
+	for i, v := range p.Versions {
 		vCopy := v
 		cv, err := parseVersionedGlobalParams(vCopy)
 
@@ -173,14 +198,20 @@ func ParseGlobalParams(p *GlobalParams) (*ParsedGlobalParams, error) {
 		if len(parsedVersions) > 0 {
 			pv := parsedVersions[len(parsedVersions)-1]
 
+			lastStakingCap := FindLastStakingCap(p.Versions[:i])
+
 			if cv.Version != pv.Version+1 {
 				return nil, fmt.Errorf("invalid params with version %d. versions should be monotonically increasing by 1", cv.Version)
 			}
-			if cv.StakingCap < pv.StakingCap {
-				return nil, fmt.Errorf("invalid params with version %d. staking cap cannot be decreased in later versions", cv.Version)
+			if cv.StakingCap != 0 && cv.StakingCap < btcutil.Amount(lastStakingCap) {
+				return nil, fmt.Errorf("invalid params with version %d. staking cap cannot be decreased in later versions, last non-zero staking cap: %d, got: %d",
+					cv.Version, lastStakingCap, cv.StakingCap)
 			}
 			if cv.ActivationHeight < pv.ActivationHeight {
 				return nil, fmt.Errorf("invalid params with version %d. activation height cannot be overlapping between earlier and later versions", cv.Version)
+			}
+			if cv.ActivationHeight <= pv.CapHeight {
+				return nil, fmt.Errorf("invalid params with version %d. activation height must be greater than the cap height of the previous version", cv.Version)
 			}
 		}
 
@@ -190,6 +221,23 @@ func ParseGlobalParams(p *GlobalParams) (*ParsedGlobalParams, error) {
 	return &ParsedGlobalParams{
 		Versions: parsedVersions,
 	}, nil
+}
+
+// FindLastStakingCap finds the last staking cap that is not zero
+// it returns zero if not non-zero value is found
+func FindLastStakingCap(prevVersions []*VersionedGlobalParams) uint64 {
+	numPrevVersions := len(prevVersions)
+	if len(prevVersions) == 0 {
+		return 0
+	}
+
+	for i := numPrevVersions - 1; i >= 0; i-- {
+		if prevVersions[i].StakingCap > 0 {
+			return prevVersions[i].StakingCap
+		}
+	}
+
+	return 0
 }
 
 func (lp *GlobalParamsRetriever) VersionedParams() *types.ParamsVersions {
@@ -276,15 +324,16 @@ func parseVersionedGlobalParams(p *VersionedGlobalParams) (*ParsedVersionedGloba
 		return nil, fmt.Errorf("invalid confirmation_depth: %w", err)
 	}
 
-	stakingCap, err := parseBtcValue(p.StakingCap)
+	stakingCap, capHeight, err := parseCap(p.StakingCap, p.CapHeight, p.ActivationHeight)
 	if err != nil {
-		return nil, fmt.Errorf("invalid staking_cap: %w", err)
+		return nil, fmt.Errorf("invalid cap: %w", err)
 	}
 
 	return &ParsedVersionedGlobalParams{
 		Version:           p.Version,
 		ActivationHeight:  p.ActivationHeight,
 		StakingCap:        stakingCap,
+		CapHeight:         capHeight,
 		Tag:               tag,
 		CovenantPks:       covenantKeys,
 		CovenantQuorum:    quroum,
@@ -311,26 +360,6 @@ func (g *ParsedGlobalParams) getVersionedGlobalParamsByHeight(btcHeight uint64) 
 	return nil
 }
 
-func (g *ParsedGlobalParams) ParamsByHeight(_ context.Context, height uint64) (*types.GlobalParams, error) {
-	versionedParams := g.getVersionedGlobalParamsByHeight(height)
-	if versionedParams == nil {
-		return nil, fmt.Errorf("no global params for height %d", height)
-	}
-
-	return &types.GlobalParams{
-		CovenantPks:       versionedParams.CovenantPks,
-		CovenantQuorum:    versionedParams.CovenantQuorum,
-		Tag:               versionedParams.Tag,
-		UnbondingTime:     versionedParams.UnbondingTime,
-		UnbondingFee:      versionedParams.UnbondingFee,
-		MaxStakingAmount:  versionedParams.MaxStakingAmount,
-		MinStakingAmount:  versionedParams.MinStakingAmount,
-		MaxStakingTime:    versionedParams.MaxStakingTime,
-		MinStakingTime:    versionedParams.MinStakingTime,
-		ConfirmationDepth: versionedParams.ConfirmationDepth,
-	}, nil
-}
-
 func (g *ParsedGlobalParams) ToGlobalParams() *types.ParamsVersions {
 	versionedParams := make([]*types.GlobalParams, len(g.Versions))
 	for i, p := range g.Versions {
@@ -338,6 +367,7 @@ func (g *ParsedGlobalParams) ToGlobalParams() *types.ParamsVersions {
 			Version:           uint16(p.Version),
 			ActivationHeight:  p.ActivationHeight,
 			StakingCap:        p.StakingCap,
+			CapHeight:         p.CapHeight,
 			Tag:               p.Tag,
 			CovenantPks:       p.CovenantPks,
 			CovenantQuorum:    p.CovenantQuorum,

--- a/testutils/datagen/params.go
+++ b/testutils/datagen/params.go
@@ -65,7 +65,6 @@ func GenerateGlobalParamsVersions(r *rand.Rand, t *testing.T) *types.ParamsVersi
 			stakingCap = lastStakingCap + btcutil.Amount(r.Int63n(1000000000)+1)
 		}
 
-		lastStakingCap = stakingCap
 		rotatedKeys := rotateCovenantPks(lastCovKeys, r, t)
 		copy(lastCovKeys, rotatedKeys)
 		paramsVersions.ParamsVersions = append(paramsVersions.ParamsVersions, &types.GlobalParams{

--- a/testutils/datagen/params.go
+++ b/testutils/datagen/params.go
@@ -18,7 +18,6 @@ func GenerateGlobalParamsVersions(r *rand.Rand, t *testing.T) *types.ParamsVersi
 	numVersions := uint16(r.Intn(10) + 1)
 
 	// For now keep the same covenants across versions
-	// TODO: consider covenants updates here
 	numCovenants := r.Intn(10) + 1
 	covPks := make([]*btcec.PublicKey, numCovenants)
 	for i := 0; i < numCovenants; i++ {
@@ -29,8 +28,10 @@ func GenerateGlobalParamsVersions(r *rand.Rand, t *testing.T) *types.ParamsVersi
 	covQuorum := uint32(r.Intn(numCovenants) + 1)
 
 	// Keep the same tag across versions
-	// TODO: consider tag updates
 	tag := []byte{0x01, 0x02, 0x03, 0x04}
+	// Keep the confirmation depth across versions
+	// the value should be at least 2
+	confirmationDepth := uint16(r.Intn(100) + 2)
 
 	paramsVersions := &types.ParamsVersions{
 		ParamsVersions: make([]*types.GlobalParams, 0),
@@ -38,8 +39,6 @@ func GenerateGlobalParamsVersions(r *rand.Rand, t *testing.T) *types.ParamsVersi
 	lastStakingCap := btcutil.Amount(0)
 	lastActivationHeight := int32(0)
 	lastCovKeys := make([]*btcec.PublicKey, numCovenants)
-	// confirmation depth is at least 2
-	confirmationDepth := uint16(r.Intn(100) + 2)
 	copy(lastCovKeys, covPks)
 	for version := uint16(0); version <= numVersions; version++ {
 		// These parameters can freely change between versions
@@ -52,18 +51,27 @@ func GenerateGlobalParamsVersions(r *rand.Rand, t *testing.T) *types.ParamsVersi
 		minStakingTime := uint16(r.Intn(1000)) + 1
 		maxStakingTime := uint16(r.Intn(10000)) + minStakingTime + 1
 
-		// These parameters should be monotonically increasing
-		// The staking cap should be more than the maximum staking amount
-		stakingCap := btcutil.Amount(r.Int63n(1000000)) +
-			btcutil.Amount(r.Int63n(100000)) + maxStakingAmount + lastStakingCap
-		lastStakingCap = stakingCap
 		activationHeight := int32(r.Intn(100)) + lastActivationHeight + 1
 		lastActivationHeight = activationHeight
+
+		// 1/3 chance to have a time-based cap
+		var capHeight uint64
+		var stakingCap btcutil.Amount
+		if r.Intn(3) == 0 {
+			capHeight = uint64(activationHeight) + uint64(r.Int63n(100)+100)
+			stakingCap = 0
+		} else {
+			lastStakingCap = findLastStakingCap(paramsVersions.ParamsVersions[:int(version)])
+			stakingCap = lastStakingCap + btcutil.Amount(r.Int63n(1000000000)+1)
+		}
+
+		lastStakingCap = stakingCap
 		rotatedKeys := rotateCovenantPks(lastCovKeys, r, t)
 		copy(lastCovKeys, rotatedKeys)
 		paramsVersions.ParamsVersions = append(paramsVersions.ParamsVersions, &types.GlobalParams{
 			Version:           version,
 			StakingCap:        stakingCap,
+			CapHeight:         capHeight,
 			ActivationHeight:  uint64(activationHeight),
 			Tag:               tag,
 			CovenantPks:       rotatedKeys,
@@ -101,4 +109,21 @@ func rotateCovenantPks(oldKeys []*btcec.PublicKey, r *rand.Rand, t *testing.T) [
 	newKeys[randIndex] = privKey.PubKey()
 
 	return newKeys
+}
+
+// findLastStakingCap finds the last staking cap that is not zero
+// it returns zero if not non-zero value is found
+func findLastStakingCap(prevVersions []*types.GlobalParams) btcutil.Amount {
+	numPrevVersions := len(prevVersions)
+	if len(prevVersions) == 0 {
+		return 0
+	}
+
+	for i := numPrevVersions - 1; i >= 0; i-- {
+		if prevVersions[i].StakingCap > 0 {
+			return prevVersions[i].StakingCap
+		}
+	}
+
+	return 0
 }

--- a/types/params.go
+++ b/types/params.go
@@ -15,6 +15,7 @@ type GlobalParams struct {
 	Version           uint16
 	ActivationHeight  uint64
 	StakingCap        btcutil.Amount
+	CapHeight         uint64
 	Tag               []byte
 	CovenantPks       []*btcec.PublicKey
 	CovenantQuorum    uint32

--- a/types/params.go
+++ b/types/params.go
@@ -44,3 +44,19 @@ func (pv *ParamsVersions) GetParamsForBTCHeight(btcHeight int32) (*GlobalParams,
 	}
 	return nil, fmt.Errorf("no version corresponds to the provided BTC height")
 }
+
+func (gp *GlobalParams) IsTimeBasedCap() (bool, error) {
+	if gp.StakingCap != 0 {
+		if gp.CapHeight != 0 {
+			return false, fmt.Errorf("only either of staking cap and cap height can be set")
+		}
+
+		return false, nil
+	}
+
+	if gp.CapHeight == 0 {
+		return false, fmt.Errorf("either of staking cap and cap height must be set")
+	}
+
+	return true, nil
+}

--- a/types/params.go
+++ b/types/params.go
@@ -45,18 +45,14 @@ func (pv *ParamsVersions) GetParamsForBTCHeight(btcHeight int32) (*GlobalParams,
 	return nil, fmt.Errorf("no version corresponds to the provided BTC height")
 }
 
-func (gp *GlobalParams) IsTimeBasedCap() (bool, error) {
-	if gp.StakingCap != 0 {
-		if gp.CapHeight != 0 {
-			return false, fmt.Errorf("only either of staking cap and cap height can be set")
-		}
-
-		return false, nil
+func (gp *GlobalParams) IsTimeBasedCap() bool {
+	if gp.StakingCap != 0 && gp.CapHeight != 0 {
+		panic(fmt.Errorf("only either of staking cap and cap height can be set"))
 	}
 
-	if gp.CapHeight == 0 {
-		return false, fmt.Errorf("either of staking cap and cap height must be set")
+	if gp.StakingCap == 0 && gp.CapHeight == 0 {
+		panic(fmt.Errorf("either of staking cap and cap height must be set"))
 	}
 
-	return true, nil
+	return gp.CapHeight != 0
 }


### PR DESCRIPTION
Closes: #96.

This PR added time-based cap to the global parameter and implemented the [algorithm](https://babylon-chain.atlassian.net/wiki/spaces/BABYLON/pages/297926664/Handle+time-based+staking+cap) to determine overflow staking transactions.