### PR TITLE
Emit confirmed info event per confirmed block

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -31,12 +31,13 @@ var (
 
 // Config is the main config for the fpd cli command
 type Config struct {
-	LogLevel       string         `long:"loglevel" description:"Logging level for all subsystems" choice:"trace" choice:"debug" choice:"info" choice:"warn" choice:"error" choice:"fatal"`
-	BitcoinNetwork string         `long:"bitcoinnetwork" description:"Bitcoin network to run on" choice:"mainnet" choice:"regtest" choice:"testnet" choice:"simnet" choice:"signet"`
-	BTCConfig      *BTCConfig     `group:"btcconfig" namespace:"btcconfig"`
-	DatabaseConfig *DBConfig      `group:"dbconfig" namespace:"dbconfig"`
-	QueueConfig    *QueueConfig   `group:"queueconfig" namespace:"queueconfig"`
-	MetricsConfig  *MetricsConfig `group:"metricsconfig" namespace:"metricsconfig"`
+	LogLevel          string         `long:"loglevel" description:"Logging level for all subsystems" choice:"trace" choice:"debug" choice:"info" choice:"warn" choice:"error" choice:"fatal"`
+	BitcoinNetwork    string         `long:"bitcoinnetwork" description:"Bitcoin network to run on" choice:"mainnet" choice:"regtest" choice:"testnet" choice:"simnet" choice:"signet"`
+	ExtraEventEnabled bool           `long:"extraeventenabled" description:"Whether emitting non-default events is allowed"`
+	BTCConfig         *BTCConfig     `group:"btcconfig" namespace:"btcconfig"`
+	DatabaseConfig    *DBConfig      `group:"dbconfig" namespace:"dbconfig"`
+	QueueConfig       *QueueConfig   `group:"queueconfig" namespace:"queueconfig"`
+	MetricsConfig     *MetricsConfig `group:"metricsconfig" namespace:"metricsconfig"`
 
 	BTCNetParams chaincfg.Params
 }

--- a/consumer/event_consumer.go
+++ b/consumer/event_consumer.go
@@ -10,5 +10,6 @@ type EventConsumer interface {
 	PushUnbondingEvent(ev *client.UnbondingStakingEvent) error
 	PushWithdrawEvent(ev *client.WithdrawStakingEvent) error
 	PushBtcInfoEvent(ev *client.BtcInfoEvent) error
+	PushConfirmedInfoEvent(ev *client.ConfirmedInfoEvent) error
 	Stop() error
 }

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/avast/retry-go/v4 v4.5.1
 	github.com/babylonchain/babylon v0.9.0-rc.1
 	github.com/babylonchain/networks/parameters v0.2.1
-	github.com/babylonchain/staking-queue-client v0.3.2-0.20240719055335-7d2b624d19e4
+	github.com/babylonchain/staking-queue-client v0.4.0
 	github.com/btcsuite/btcd v0.24.0
 	github.com/btcsuite/btcd/btcec/v2 v2.3.2
 	github.com/btcsuite/btcd/btcutil v1.1.5

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/avast/retry-go/v4 v4.5.1
 	github.com/babylonchain/babylon v0.9.0-rc.1
 	github.com/babylonchain/networks/parameters v0.2.1
-	github.com/babylonchain/staking-queue-client v0.2.1
+	github.com/babylonchain/staking-queue-client v0.3.2-0.20240719055335-7d2b624d19e4
 	github.com/btcsuite/btcd v0.24.0
 	github.com/btcsuite/btcd/btcec/v2 v2.3.2
 	github.com/btcsuite/btcd/btcutil v1.1.5

--- a/go.sum
+++ b/go.sum
@@ -285,8 +285,8 @@ github.com/babylonchain/babylon v0.9.0-rc.1 h1:mZYKQVHVKFUA2xaEAzJloB1kyePHvZECJ
 github.com/babylonchain/babylon v0.9.0-rc.1/go.mod h1:YFALTW+Kp/b5jSDoA7Z70RggJjAedlmQTrpdeU8c3hY=
 github.com/babylonchain/networks/parameters v0.2.1 h1:OKHiCnwL/UdVN17cMwCrHz/bAjO/USauLiPyNlnVl6E=
 github.com/babylonchain/networks/parameters v0.2.1/go.mod h1:nejhvrL7Iwh5Vunvkg7pnomQZlHnyNzOY9lQaDp6tOA=
-github.com/babylonchain/staking-queue-client v0.2.1 h1:FKbxUUOoCydAsUoj9XQMIQT1S79ThX9p7vVc5yjWm8c=
-github.com/babylonchain/staking-queue-client v0.2.1/go.mod h1:mEgA6N3SnwFwGEOsUYr/HdjpKa13Wck08MS7VY/Icvo=
+github.com/babylonchain/staking-queue-client v0.3.2-0.20240719055335-7d2b624d19e4 h1:rojrwUtql8O4QUQ+AUa3XeTtrdQT7MWG0RlqLsNsXRA=
+github.com/babylonchain/staking-queue-client v0.3.2-0.20240719055335-7d2b624d19e4/go.mod h1:mEgA6N3SnwFwGEOsUYr/HdjpKa13Wck08MS7VY/Icvo=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=

--- a/go.sum
+++ b/go.sum
@@ -285,8 +285,8 @@ github.com/babylonchain/babylon v0.9.0-rc.1 h1:mZYKQVHVKFUA2xaEAzJloB1kyePHvZECJ
 github.com/babylonchain/babylon v0.9.0-rc.1/go.mod h1:YFALTW+Kp/b5jSDoA7Z70RggJjAedlmQTrpdeU8c3hY=
 github.com/babylonchain/networks/parameters v0.2.1 h1:OKHiCnwL/UdVN17cMwCrHz/bAjO/USauLiPyNlnVl6E=
 github.com/babylonchain/networks/parameters v0.2.1/go.mod h1:nejhvrL7Iwh5Vunvkg7pnomQZlHnyNzOY9lQaDp6tOA=
-github.com/babylonchain/staking-queue-client v0.3.2-0.20240719055335-7d2b624d19e4 h1:rojrwUtql8O4QUQ+AUa3XeTtrdQT7MWG0RlqLsNsXRA=
-github.com/babylonchain/staking-queue-client v0.3.2-0.20240719055335-7d2b624d19e4/go.mod h1:mEgA6N3SnwFwGEOsUYr/HdjpKa13Wck08MS7VY/Icvo=
+github.com/babylonchain/staking-queue-client v0.4.0 h1:uKClZqFgksUo9tfVwIVCMtDjJk8YzOBsx7IwlJEP3fw=
+github.com/babylonchain/staking-queue-client v0.4.0/go.mod h1:mEgA6N3SnwFwGEOsUYr/HdjpKa13Wck08MS7VY/Icvo=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -383,14 +383,16 @@ func (si *StakingIndexer) HandleConfirmedBlock(b *types.IndexedBlock) error {
 		return fmt.Errorf("failed to save the last processed height: %w", err)
 	}
 
-	// emit ConfirmedInfoEvent to send the confirmed height and tvl
-	confirmedTvl, err := si.is.GetConfirmedTvl()
-	if err != nil {
-		return fmt.Errorf("failed to get the confirmed tvl: %w", err)
-	}
-	confirmedInfoEvent := queuecli.NewConfirmedInfoEvent(uint64(b.Height), confirmedTvl)
-	if err := si.consumer.PushConfirmedInfoEvent(&confirmedInfoEvent); err != nil {
-		return fmt.Errorf("failed to push the confirmed info event: %w", err)
+	if si.cfg.ExtraEventEnabled {
+		// emit ConfirmedInfoEvent to send the confirmed height and tvl
+		confirmedTvl, err := si.is.GetConfirmedTvl()
+		if err != nil {
+			return fmt.Errorf("failed to get the confirmed tvl: %w", err)
+		}
+		confirmedInfoEvent := queuecli.NewConfirmedInfoEvent(uint64(b.Height), confirmedTvl)
+		if err := si.consumer.PushConfirmedInfoEvent(&confirmedInfoEvent); err != nil {
+			return fmt.Errorf("failed to push the confirmed info event: %w", err)
+		}
 	}
 
 	// record metrics

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -383,6 +383,16 @@ func (si *StakingIndexer) HandleConfirmedBlock(b *types.IndexedBlock) error {
 		return fmt.Errorf("failed to save the last processed height: %w", err)
 	}
 
+	// emit ConfirmedInfoEvent to send the confirmed height and tvl
+	confirmedTvl, err := si.is.GetConfirmedTvl()
+	if err != nil {
+		return fmt.Errorf("failed to get the confirmed tvl: %w", err)
+	}
+	confirmedInfoEvent := queuecli.NewConfirmedInfoEvent(uint64(b.Height), confirmedTvl)
+	if err := si.consumer.PushConfirmedInfoEvent(&confirmedInfoEvent); err != nil {
+		return fmt.Errorf("failed to push the confirmed info event: %w", err)
+	}
+
 	// record metrics
 	lastProcessedBtcHeight.Set(float64(b.Height))
 

--- a/indexer/indexer_test.go
+++ b/indexer/indexer_test.go
@@ -595,7 +595,6 @@ func NewMockedConsumer(t *testing.T) *mocks.MockEventConsumer {
 	mockedConsumer.EXPECT().PushStakingEvent(gomock.Any()).Return(nil).AnyTimes()
 	mockedConsumer.EXPECT().PushUnbondingEvent(gomock.Any()).Return(nil).AnyTimes()
 	mockedConsumer.EXPECT().PushWithdrawEvent(gomock.Any()).Return(nil).AnyTimes()
-	mockedConsumer.EXPECT().PushConfirmedInfoEvent(gomock.Any()).Return(nil).AnyTimes()
 	mockedConsumer.EXPECT().Start().Return(nil).AnyTimes()
 	mockedConsumer.EXPECT().Stop().Return(nil).AnyTimes()
 

--- a/indexer/indexer_test.go
+++ b/indexer/indexer_test.go
@@ -595,6 +595,7 @@ func NewMockedConsumer(t *testing.T) *mocks.MockEventConsumer {
 	mockedConsumer.EXPECT().PushStakingEvent(gomock.Any()).Return(nil).AnyTimes()
 	mockedConsumer.EXPECT().PushUnbondingEvent(gomock.Any()).Return(nil).AnyTimes()
 	mockedConsumer.EXPECT().PushWithdrawEvent(gomock.Any()).Return(nil).AnyTimes()
+	mockedConsumer.EXPECT().PushConfirmedInfoEvent(gomock.Any()).Return(nil).AnyTimes()
 	mockedConsumer.EXPECT().Start().Return(nil).AnyTimes()
 	mockedConsumer.EXPECT().Stop().Return(nil).AnyTimes()
 

--- a/itest/e2e_test.go
+++ b/itest/e2e_test.go
@@ -99,11 +99,14 @@ func TestStakingLifeCycle(t *testing.T) {
 	stakingTxHash := stakingTx.TxHash()
 	tm.SendTxWithNConfirmations(t, stakingTx, int(k))
 
+	tm.CheckConfirmedInfoEvent(t, 100, 0)
+
 	// check that the staking tx is already stored
 	_ = tm.WaitForStakingTxStored(t, stakingTxHash)
 
 	// check the staking event is received by the queue
 	tm.CheckNextStakingEvent(t, stakingTxHash)
+	tm.CheckConfirmedInfoEvent(t, 102, uint64(testStakingData.StakingAmount))
 
 	// wait for the staking tx expires
 	if uint64(testStakingData.StakingTime) > k {

--- a/itest/test_manager.go
+++ b/itest/test_manager.go
@@ -39,23 +39,24 @@ import (
 )
 
 type TestManager struct {
-	Config             *config.Config
-	Db                 kvdb.Backend
-	Si                 *indexer.StakingIndexer
-	BS                 *btcscanner.BtcPoller
-	WalletPrivKey      *btcec.PrivateKey
-	serverStopper      *signal.Interceptor
-	wg                 *sync.WaitGroup
-	BitcoindHandler    *BitcoindTestHandler
-	WalletClient       *rpcclient.Client
-	MinerAddr          btcutil.Address
-	DirPath            string
-	QueueConsumer      *queuemngr.QueueManager
-	StakingEventChan   <-chan queuecli.QueueMessage
-	UnbondingEventChan <-chan queuecli.QueueMessage
-	WithdrawEventChan  <-chan queuecli.QueueMessage
-	BtcInfoEventChan   <-chan queuecli.QueueMessage
-	VersionedParams    *parser.ParsedGlobalParams
+	Config                 *config.Config
+	Db                     kvdb.Backend
+	Si                     *indexer.StakingIndexer
+	BS                     *btcscanner.BtcPoller
+	WalletPrivKey          *btcec.PrivateKey
+	serverStopper          *signal.Interceptor
+	wg                     *sync.WaitGroup
+	BitcoindHandler        *BitcoindTestHandler
+	WalletClient           *rpcclient.Client
+	MinerAddr              btcutil.Address
+	DirPath                string
+	QueueConsumer          *queuemngr.QueueManager
+	StakingEventChan       <-chan queuecli.QueueMessage
+	UnbondingEventChan     <-chan queuecli.QueueMessage
+	WithdrawEventChan      <-chan queuecli.QueueMessage
+	BtcInfoEventChan       <-chan queuecli.QueueMessage
+	ConfirmedInfoEventChan <-chan queuecli.QueueMessage
+	VersionedParams        *parser.ParsedGlobalParams
 }
 
 // bitcoin params used for testing
@@ -146,6 +147,8 @@ func StartWithBitcoinHandler(t *testing.T, h *BitcoindTestHandler, minerAddress 
 	require.NoError(t, err)
 	unconfirmedEventChan, err := queueConsumer.BtcInfoQueue.ReceiveMessages()
 	require.NoError(t, err)
+	confirmedInfoEventChan, err := queueConsumer.ConfirmedInfoQueue.ReceiveMessages()
+	require.NoError(t, err)
 
 	db, err := cfg.DatabaseConfig.GetDbBackend()
 	require.NoError(t, err)
@@ -176,22 +179,23 @@ func StartWithBitcoinHandler(t *testing.T, h *BitcoindTestHandler, minerAddress 
 	time.Sleep(3 * time.Second)
 
 	return &TestManager{
-		Config:             cfg,
-		Si:                 si,
-		BS:                 scanner,
-		serverStopper:      &interceptor,
-		wg:                 &wg,
-		BitcoindHandler:    h,
-		WalletClient:       rpcclient,
-		WalletPrivKey:      walletPrivKey.PrivKey,
-		MinerAddr:          minerAddress,
-		DirPath:            dirPath,
-		QueueConsumer:      queueConsumer,
-		StakingEventChan:   stakingEventChan,
-		UnbondingEventChan: unbondingEventChan,
-		WithdrawEventChan:  withdrawEventChan,
-		BtcInfoEventChan:   unconfirmedEventChan,
-		VersionedParams:    versionedParams,
+		Config:                 cfg,
+		Si:                     si,
+		BS:                     scanner,
+		serverStopper:          &interceptor,
+		wg:                     &wg,
+		BitcoindHandler:        h,
+		WalletClient:           rpcclient,
+		WalletPrivKey:          walletPrivKey.PrivKey,
+		MinerAddr:              minerAddress,
+		DirPath:                dirPath,
+		QueueConsumer:          queueConsumer,
+		StakingEventChan:       stakingEventChan,
+		UnbondingEventChan:     unbondingEventChan,
+		WithdrawEventChan:      withdrawEventChan,
+		BtcInfoEventChan:       unconfirmedEventChan,
+		ConfirmedInfoEventChan: confirmedInfoEventChan,
+		VersionedParams:        versionedParams,
 	}
 }
 
@@ -361,6 +365,23 @@ func (tm *TestManager) CheckNextWithdrawEvent(t *testing.T, stakingTxHash chainh
 	require.NoError(t, err)
 }
 
+func (tm *TestManager) CheckConfirmedInfoEvent(t *testing.T, height, tvl uint64) {
+	var confirmedInfoEv queuecli.ConfirmedInfoEvent
+
+	for {
+		confirmedInfoEventBytes := <-tm.ConfirmedInfoEventChan
+		err := tm.QueueConsumer.ConfirmedInfoQueue.DeleteMessage(confirmedInfoEventBytes.Receipt)
+		require.NoError(t, err)
+		err = json.Unmarshal([]byte(confirmedInfoEventBytes.Body), &confirmedInfoEv)
+		require.NoError(t, err)
+		if height != confirmedInfoEv.Height {
+			continue
+		}
+		require.Equal(t, confirmedInfoEv.Tvl, tvl)
+		return
+	}
+}
+
 func (tm *TestManager) CheckNextUnconfirmedEvent(t *testing.T, confirmedTvl, totalTvl uint64) {
 	var btcInfoEvent queuecli.BtcInfoEvent
 
@@ -376,6 +397,7 @@ func (tm *TestManager) CheckNextUnconfirmedEvent(t *testing.T, confirmedTvl, tot
 		if totalTvl != btcInfoEvent.UnconfirmedTvl {
 			continue
 		}
+		
 		return
 	}
 }

--- a/itest/test_manager.go
+++ b/itest/test_manager.go
@@ -218,7 +218,10 @@ func ReStartFromHeight(t *testing.T, tm *TestManager, height uint64) *TestManage
 func DefaultStakingIndexerConfig(homePath string) *config.Config {
 	defaultConfig := config.DefaultConfigWithHome(homePath)
 
-	// both wallet and node are bicoind
+	// enable emitting extra events for testing
+	defaultConfig.ExtraEventEnabled = true
+
+	// both wallet and node are bitcoind
 	defaultConfig.BTCNetParams = *regtestParams
 
 	bitcoindHost := "127.0.0.1:18443"

--- a/itest/test_manager.go
+++ b/itest/test_manager.go
@@ -397,7 +397,7 @@ func (tm *TestManager) CheckNextUnconfirmedEvent(t *testing.T, confirmedTvl, tot
 		if totalTvl != btcInfoEvent.UnconfirmedTvl {
 			continue
 		}
-		
+
 		return
 	}
 }

--- a/testutils/mocks/event_consumer.go
+++ b/testutils/mocks/event_consumer.go
@@ -48,6 +48,20 @@ func (mr *MockEventConsumerMockRecorder) PushBtcInfoEvent(ev interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PushBtcInfoEvent", reflect.TypeOf((*MockEventConsumer)(nil).PushBtcInfoEvent), ev)
 }
 
+// PushConfirmedInfoEvent mocks base method.
+func (m *MockEventConsumer) PushConfirmedInfoEvent(ev *client.ConfirmedInfoEvent) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PushConfirmedInfoEvent", ev)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PushConfirmedInfoEvent indicates an expected call of PushConfirmedInfoEvent.
+func (mr *MockEventConsumerMockRecorder) PushConfirmedInfoEvent(ev interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PushConfirmedInfoEvent", reflect.TypeOf((*MockEventConsumer)(nil).PushConfirmedInfoEvent), ev)
+}
+
 // PushStakingEvent mocks base method.
 func (m *MockEventConsumer) PushStakingEvent(ev *client.ActiveStakingEvent) error {
 	m.ctrl.T.Helper()

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,5 +1,0 @@
-module github.com/babylonchain/finality-provider/tools
-
-go 1.21
-
-toolchain go1.21.4

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,4 +1,0 @@
-//go:build tools
-// +build tools
-
-package stakingindexer


### PR DESCRIPTION
This PR introduce the emitting of confirmed info event before finishing handling a confirmed block. This sends the confirmed height along with confirmed tvl in the event. Given that the indexer ensures all the confirmed blocks are handled in the order of block height, no tvl data will be missed