### PR TITLE
chore: new flag export only header bytes

### DIFF
--- a/cmd/sid/cli/btc_headers_test.go
+++ b/cmd/sid/cli/btc_headers_test.go
@@ -36,7 +36,7 @@ func FuzzBtcHeaders(f *testing.F) {
 				Return(idxBlock.Header, nil).AnyTimes()
 		}
 
-		infos, err := cli.BtcHeaderInfoList(mockBtcClient, startHeight, endHeight)
+		infos, err := cli.BtcHeaderInfoList(mockBtcClient, startHeight, endHeight, false)
 		require.NoError(t, err)
 		require.EqualValues(t, len(infos), numBlocks)
 

--- a/itest/e2e_test.go
+++ b/itest/e2e_test.go
@@ -644,7 +644,7 @@ func TestBtcHeaders(t *testing.T) {
 	btcd, btcClient := StartBtcClientAndBtcHandler(t, initBlocksQnt)
 
 	// from zero height
-	infos, err := cli.BtcHeaderInfoList(btcClient, 0, uint64(initBlocksQnt))
+	infos, err := cli.BtcHeaderInfoList(btcClient, 0, uint64(initBlocksQnt), false)
 	require.NoError(t, err)
 	require.Equal(t, len(infos), initBlocksQnt+1)
 
@@ -660,7 +660,7 @@ func TestBtcHeaders(t *testing.T) {
 	fromBlockHeight := blocksPerRetarget - 1
 	toBlockHeight := totalBlks - 2
 
-	infos, err = cli.BtcHeaderInfoList(btcClient, uint64(fromBlockHeight), uint64(toBlockHeight))
+	infos, err = cli.BtcHeaderInfoList(btcClient, uint64(fromBlockHeight), uint64(toBlockHeight), false)
 	require.NoError(t, err)
 	require.Equal(t, len(infos), int(toBlockHeight-fromBlockHeight)+1)
 
@@ -669,7 +669,7 @@ func TestBtcHeaders(t *testing.T) {
 	require.EqualError(t, genState.Validate(), "genesis block must be a difficulty adjustment block")
 
 	// from retarget block
-	infos, err = cli.BtcHeaderInfoList(btcClient, uint64(blocksPerRetarget), uint64(totalBlks))
+	infos, err = cli.BtcHeaderInfoList(btcClient, uint64(blocksPerRetarget), uint64(totalBlks), false)
 	require.NoError(t, err)
 	require.Equal(t, len(infos), int(totalBlks-blocksPerRetarget)+1)
 


### PR DESCRIPTION
Created new structure to avoid exporting `params: []` empty as it was before by using the `bbnbtclightclienttypes.GenState` as before

Add new flag `only-header-bytes` to `btc-headers` command